### PR TITLE
Stop celery result deletion

### DIFF
--- a/openff/bespokefit/executor/utilities/celery.py
+++ b/openff/bespokefit/executor/utilities/celery.py
@@ -50,6 +50,7 @@ def configure_celery_app(
     celery_app.conf.task_track_started = True
     celery_app.conf.task_default_queue = app_name
     celery_app.conf.broker_transport_options = {"visibility_timeout": 1000000}
+    celery_app.conf.result_expires = None
 
     return celery_app
 


### PR DESCRIPTION
## Description
This PR should stop saved celery results from being deleted after 1 day they should now be saved indefinitely.  Previously this would cause any cached stages to hang when trying to find the result in redis after it had been removed. 


## Status
- [x] Ready to go