### PR TITLE
Parameter cache

### DIFF
--- a/openff/bespokefit/executor/executor.py
+++ b/openff/bespokefit/executor/executor.py
@@ -48,9 +48,9 @@ class BespokeExecutor:
 
     def __init__(
         self,
-        n_fragmenter_workers: int = 0,
-        n_qc_compute_workers: int = 0,
-        n_optimizer_workers: int = 0,
+        n_fragmenter_workers: int = 1,
+        n_qc_compute_workers: int = 1,
+        n_optimizer_workers: int = 1,
         directory: Optional[str] = "bespoke-executor",
         launch_redis_if_unavailable: bool = True,
     ):

--- a/openff/bespokefit/executor/services/coordinator/stages.py
+++ b/openff/bespokefit/executor/services/coordinator/stages.py
@@ -1,10 +1,11 @@
 import abc
 import json
 from collections import defaultdict
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import httpx
-from openff.fragmenter.fragment import FragmentationResult
+import redis
+from openff.fragmenter.fragment import Fragment, FragmentationResult
 from openff.toolkit.typing.engines.smirnoff import (
     AngleHandler,
     BondHandler,
@@ -20,6 +21,7 @@ from qcengine.procedures.torsiondrive import TorsionDriveResult
 from typing_extensions import Literal
 
 from openff.bespokefit.executor.services import settings
+from openff.bespokefit.executor.services.coordinator.utils import get_cached_parameters
 from openff.bespokefit.executor.services.fragmenter.models import (
     FragmenterGETResponse,
     FragmenterPOSTBody,
@@ -35,6 +37,7 @@ from openff.bespokefit.executor.services.qcgenerator.models import (
     QCGeneratorPOSTBody,
     QCGeneratorPOSTResponse,
 )
+from openff.bespokefit.executor.utilities.redis import is_redis_available
 from openff.bespokefit.executor.utilities.typing import Status
 from openff.bespokefit.schema.data import BespokeQCData, LocalQCData
 from openff.bespokefit.schema.fitting import BespokeOptimizationSchema
@@ -52,6 +55,7 @@ from openff.bespokefit.utilities.smirks import (
     ForceFieldEditor,
     SMIRKSGenerator,
     SMIRKSType,
+    get_cached_torsion_parameters,
 )
 
 if TYPE_CHECKING:
@@ -190,6 +194,151 @@ class QCGenerationStage(_Stage):
         Dict[str, Union[AtomicResult, OptimizationResult, TorsionDriveResult]]
     ] = Field(None, description="")
 
+    @staticmethod
+    def _generate_torsion_parameters(
+        fragmentation_result: FragmentationResult,
+        input_schema: BespokeOptimizationSchema,
+    ) -> Tuple[List[ParameterType], List[Fragment]]:
+        """
+        Generate torsion parameters for the fragments using any possible cached parameters.
+
+        Args:
+            fragmentation_result: The result of the fragmentation
+            input_schema: The input schema detailing the optimisation
+
+        Returns:
+            The list of generated smirks patterns including any cached values, and a list of fragments which require torsiondrives.
+        """
+        cached_torsions = None
+
+        if is_redis_available(
+            host=settings.BEFLOW_REDIS_ADDRESS, port=settings.BEFLOW_REDIS_PORT
+        ):
+            redis_connection = redis.Redis(
+                host=settings.BEFLOW_REDIS_ADDRESS,
+                port=settings.BEFLOW_REDIS_PORT,
+                db=settings.BEFLOW_REDIS_DB,
+            )
+            cached_force_field = get_cached_parameters(
+                fitting_schema=input_schema, redis_connection=redis_connection
+            )
+            if cached_force_field is not None:
+                cached_torsions = cached_force_field["ProperTorsions"].parameters
+
+        parent = fragmentation_result.parent_molecule
+        smirks_gen = SMIRKSGenerator(
+            initial_force_field=input_schema.initial_force_field,
+            generate_bespoke_terms=input_schema.smirk_settings.generate_bespoke_terms,
+            expand_torsion_terms=input_schema.smirk_settings.expand_torsion_terms,
+            target_smirks=[SMIRKSType.ProperTorsions],
+        )
+
+        new_smirks = []
+        fragments = []
+        for fragment_data in fragmentation_result.fragments:
+            central_bond = fragment_data.bond_indices
+            fragment_molecule = fragment_data.molecule
+            bespoke_smirks = smirks_gen.generate_smirks_from_fragment(
+                parent=parent,
+                fragment=fragment_molecule,
+                fragment_map_indices=central_bond,
+            )
+            if cached_torsions is not None:
+                smirks_to_add = []
+                for smirk in bespoke_smirks:
+                    cached_smirk = get_cached_torsion_parameters(
+                        molecule=fragment_molecule,
+                        bespoke_parameter=smirk,
+                        cached_parameters=cached_torsions,
+                    )
+                    if cached_smirk is not None:
+                        smirks_to_add.append(cached_smirk)
+                if len(smirks_to_add) == len(bespoke_smirks):
+                    # if we have the same number of parameters we are safe to transfer as they were fit together
+                    new_smirks.extend(smirks_to_add)
+                else:
+                    # the cached parameter was not fit with the correct number of other parameters
+                    # so use new terms not cached
+                    new_smirks.extend(bespoke_smirks)
+                    fragments.append(fragment_data)
+
+            else:
+                new_smirks.extend(bespoke_smirks)
+                # only keep track of fragments which require QM calculations as they have no cached values
+                fragments.append(fragment_data)
+
+        return new_smirks, fragments
+
+    @staticmethod
+    async def _generate_parameters(
+        input_schema: BespokeOptimizationSchema,
+        fragmentation_result: Optional[FragmentationResult],
+    ) -> List[Fragment]:
+        """
+        Generate a list of parameters which are to be optimised, these are added to the input force field.
+        The parameters are also added to the parameter list in each stage corresponding to the stage where they will be fit.
+        """
+
+        initial_force_field = ForceFieldEditor(input_schema.initial_force_field)
+        new_parameters = []
+
+        target_smirks = {*input_schema.target_smirks}
+        if SMIRKSType.ProperTorsions in target_smirks:
+            target_smirks.remove(SMIRKSType.ProperTorsions)
+
+            (
+                torsion_parameters,
+                fragment_jobs,
+            ) = QCGenerationStage._generate_torsion_parameters(
+                fragmentation_result=fragmentation_result,
+                input_schema=input_schema,
+            )
+            new_parameters.extend(torsion_parameters)
+        else:
+            fragment_jobs = []
+
+        if len(target_smirks) > 0:
+            smirks_gen = SMIRKSGenerator(
+                initial_force_field=input_schema.initial_force_field,
+                generate_bespoke_terms=input_schema.smirk_settings.generate_bespoke_terms,
+                target_smirks=[*target_smirks],
+                smirks_layers=1,
+            )
+
+            parameters = smirks_gen.generate_smirks_from_molecule(
+                molecule=input_schema.molecule
+            )
+            new_parameters.extend(parameters)
+
+        # add all new terms to the input force field
+        initial_force_field.add_parameters(parameters=new_parameters)
+
+        parameter_to_type = {
+            vdWHandler.vdWType: VdWSMIRKS,
+            BondHandler.BondType: BondSMIRKS,
+            AngleHandler.AngleType: AngleSMIRKS,
+            ProperTorsionHandler.ProperTorsionType: ProperTorsionSMIRKS,
+            ImproperTorsionHandler.ImproperTorsionType: ImproperTorsionSMIRKS,
+        }
+        # convert all parameters to bespokefit types
+        parameters_to_fit = defaultdict(list)
+        for parameter in new_parameters:
+            bespoke_parameter = parameter_to_type[parameter.__class__].from_smirnoff(
+                parameter
+            )
+            # We only want to fit if it was not cached
+            if not bespoke_parameter.cached:
+                parameters_to_fit[bespoke_parameter.type].append(bespoke_parameter)
+
+        # set which parameters should be optimised in each stage
+        for stage in input_schema.stages:
+            for hyper_param in stage.parameter_hyperparameters:
+                stage.parameters.extend(parameters_to_fit[hyper_param.type])
+
+        input_schema.initial_force_field = initial_force_field.force_field.to_string()
+
+        return fragment_jobs
+
     async def _enter(self, task: "CoordinatorTask"):
 
         fragment_stage = next(
@@ -200,9 +349,24 @@ class QCGenerationStage(_Stage):
             ),
             None,
         )
-        fragments = (
-            [] if fragment_stage.result is None else fragment_stage.result.fragments
-        )
+
+        input_schema = task.input_schema
+
+        # TODO: Move these methods onto the celery worker.
+        try:
+            fragments = await self._generate_parameters(
+                fragmentation_result=fragment_stage.result,
+                input_schema=input_schema,
+            )
+        except BaseException as e:  # lgtm [py/catch-base-exception]
+
+            self.status = "errored"
+            self.error = json.dumps(
+                f"Failed to generate SMIRKS patterns that match both the parent and "
+                f"torsion fragments: {str(e)}"
+            )
+
+            return
 
         target_qc_tasks = defaultdict(list)
 
@@ -221,7 +385,7 @@ class QCGenerationStage(_Stage):
                     Torsion1DTask(
                         smiles=fragment.smiles,
                         central_bond=fragment.bond_indices,
-                        **target.reference_data.spec.dict(),
+                        **target.calculation_specification.dict(),
                     )
                     for fragment in fragments
                 )
@@ -332,93 +496,93 @@ class OptimizationStage(_Stage):
         None, description="The result of the optimization."
     )
 
-    @staticmethod
-    def _generate_torsion_parameters(
-        fragmentation_result: FragmentationResult,
-        input_schema: BespokeOptimizationSchema,
-    ) -> List[ParameterType]:
-
-        parent = fragmentation_result.parent_molecule
-        smirks_gen = SMIRKSGenerator(
-            initial_force_field=input_schema.initial_force_field,
-            generate_bespoke_terms=input_schema.smirk_settings.generate_bespoke_terms,
-            expand_torsion_terms=input_schema.smirk_settings.expand_torsion_terms,
-            target_smirks=[SMIRKSType.ProperTorsions],
-        )
-
-        new_smirks = []
-        for fragment_data in fragmentation_result.fragments:
-            central_bond = fragment_data.bond_indices
-            fragment_molecule = fragment_data.molecule
-            smirks = smirks_gen.generate_smirks_from_fragment(
-                parent=parent,
-                fragment=fragment_molecule,
-                fragment_map_indices=central_bond,
-            )
-            new_smirks.extend(smirks)
-
-        return new_smirks
-
-    @staticmethod
-    async def _generate_parameters(
-        input_schema: BespokeOptimizationSchema,
-        fragmentation_result: Optional[FragmentationResult],
-    ):
-        """
-        Generate a list of parameters which are to be optimised, these are added to the input force field.
-        The parameters are also added to the parameter list in each stage corresponding to the stage where they will be fit.
-        """
-
-        initial_force_field = ForceFieldEditor(input_schema.initial_force_field)
-        new_parameters = []
-
-        target_smirks = {*input_schema.target_smirks}
-        if SMIRKSType.ProperTorsions in target_smirks:
-            target_smirks.remove(SMIRKSType.ProperTorsions)
-
-            torsion_parameters = OptimizationStage._generate_torsion_parameters(
-                fragmentation_result=fragmentation_result,
-                input_schema=input_schema,
-            )
-            new_parameters.extend(torsion_parameters)
-
-        if len(target_smirks) > 0:
-            smirks_gen = SMIRKSGenerator(
-                initial_force_field=input_schema.initial_force_field,
-                generate_bespoke_terms=input_schema.smirk_settings.generate_bespoke_terms,
-                target_smirks=[*target_smirks],
-                smirks_layers=1,
-            )
-
-            parameters = smirks_gen.generate_smirks_from_molecule(
-                molecule=input_schema.molecule
-            )
-            new_parameters.extend(parameters)
-
-        # add all new terms to the input force field
-        initial_force_field.add_parameters(parameters=new_parameters)
-
-        parameter_to_type = {
-            vdWHandler.vdWType: VdWSMIRKS,
-            BondHandler.BondType: BondSMIRKS,
-            AngleHandler.AngleType: AngleSMIRKS,
-            ProperTorsionHandler.ProperTorsionType: ProperTorsionSMIRKS,
-            ImproperTorsionHandler.ImproperTorsionType: ImproperTorsionSMIRKS,
-        }
-        # convert all parameters to bespokefit types
-        parameters_to_fit = defaultdict(list)
-        for parameter in new_parameters:
-            bespoke_parameter = parameter_to_type[parameter.__class__].from_smirnoff(
-                parameter
-            )
-            parameters_to_fit[bespoke_parameter.type].append(bespoke_parameter)
-
-        # set which parameters should be optimised in each stage
-        for stage in input_schema.stages:
-            for hyper_param in stage.parameter_hyperparameters:
-                stage.parameters.extend(parameters_to_fit[hyper_param.type])
-
-        input_schema.initial_force_field = initial_force_field.force_field.to_string()
+    # @staticmethod
+    # def _generate_torsion_parameters(
+    #     fragmentation_result: FragmentationResult,
+    #     input_schema: BespokeOptimizationSchema,
+    # ) -> List[ParameterType]:
+    #
+    #     parent = fragmentation_result.parent_molecule
+    #     smirks_gen = SMIRKSGenerator(
+    #         initial_force_field=input_schema.initial_force_field,
+    #         generate_bespoke_terms=input_schema.smirk_settings.generate_bespoke_terms,
+    #         expand_torsion_terms=input_schema.smirk_settings.expand_torsion_terms,
+    #         target_smirks=[SMIRKSType.ProperTorsions],
+    #     )
+    #
+    #     new_smirks = []
+    #     for fragment_data in fragmentation_result.fragments:
+    #         central_bond = fragment_data.bond_indices
+    #         fragment_molecule = fragment_data.molecule
+    #         smirks = smirks_gen.generate_smirks_from_fragment(
+    #             parent=parent,
+    #             fragment=fragment_molecule,
+    #             fragment_map_indices=central_bond,
+    #         )
+    #         new_smirks.extend(smirks)
+    #
+    #     return new_smirks
+    #
+    # @staticmethod
+    # async def _generate_parameters(
+    #     input_schema: BespokeOptimizationSchema,
+    #     fragmentation_result: Optional[FragmentationResult],
+    # ):
+    #     """
+    #     Generate a list of parameters which are to be optimised, these are added to the input force field.
+    #     The parameters are also added to the parameter list in each stage corresponding to the stage where they will be fit.
+    #     """
+    #
+    #     initial_force_field = ForceFieldEditor(input_schema.initial_force_field)
+    #     new_parameters = []
+    #
+    #     target_smirks = {*input_schema.target_smirks}
+    #     if SMIRKSType.ProperTorsions in target_smirks:
+    #         target_smirks.remove(SMIRKSType.ProperTorsions)
+    #
+    #         torsion_parameters = OptimizationStage._generate_torsion_parameters(
+    #             fragmentation_result=fragmentation_result,
+    #             input_schema=input_schema,
+    #         )
+    #         new_parameters.extend(torsion_parameters)
+    #
+    #     if len(target_smirks) > 0:
+    #         smirks_gen = SMIRKSGenerator(
+    #             initial_force_field=input_schema.initial_force_field,
+    #             generate_bespoke_terms=input_schema.smirk_settings.generate_bespoke_terms,
+    #             target_smirks=[*target_smirks],
+    #             smirks_layers=1,
+    #         )
+    #
+    #         parameters = smirks_gen.generate_smirks_from_molecule(
+    #             molecule=input_schema.molecule
+    #         )
+    #         new_parameters.extend(parameters)
+    #
+    #     # add all new terms to the input force field
+    #     initial_force_field.add_parameters(parameters=new_parameters)
+    #
+    #     parameter_to_type = {
+    #         vdWHandler.vdWType: VdWSMIRKS,
+    #         BondHandler.BondType: BondSMIRKS,
+    #         AngleHandler.AngleType: AngleSMIRKS,
+    #         ProperTorsionHandler.ProperTorsionType: ProperTorsionSMIRKS,
+    #         ImproperTorsionHandler.ImproperTorsionType: ImproperTorsionSMIRKS,
+    #     }
+    #     # convert all parameters to bespokefit types
+    #     parameters_to_fit = defaultdict(list)
+    #     for parameter in new_parameters:
+    #         bespoke_parameter = parameter_to_type[parameter.__class__].from_smirnoff(
+    #             parameter
+    #         )
+    #         parameters_to_fit[bespoke_parameter.type].append(bespoke_parameter)
+    #
+    #     # set which parameters should be optimised in each stage
+    #     for stage in input_schema.stages:
+    #         for hyper_param in stage.parameter_hyperparameters:
+    #             stage.parameters.extend(parameters_to_fit[hyper_param.type])
+    #
+    #     input_schema.initial_force_field = initial_force_field.force_field.to_string()
 
     @staticmethod
     async def _inject_bespoke_qc_data(
@@ -451,7 +615,7 @@ class OptimizationStage(_Stage):
         ]
         n_targets_missing_qc_data = len(targets_missing_qc_data)
 
-        if n_targets_missing_qc_data > 0:
+        if n_targets_missing_qc_data > 0 and qc_generation_stage.results:
 
             raise RuntimeError(
                 f"{n_targets_missing_qc_data} targets were missing QC data - this "
@@ -465,24 +629,24 @@ class OptimizationStage(_Stage):
 
         input_schema = task.input_schema.copy(deep=True)
 
-        # Generate all parameters to be optimised
-        fragmentation_stage: FragmentationStage = completed_stages["fragmentation"]
+        # # Generate all parameters to be optimised
+        # fragmentation_stage: FragmentationStage = completed_stages["fragmentation"]
 
-        # TODO: Move these methods onto the celery worker.
-        try:
-            await self._generate_parameters(
-                fragmentation_result=fragmentation_stage.result,
-                input_schema=input_schema,
-            )
-        except BaseException as e:  # lgtm [py/catch-base-exception]
-
-            self.status = "errored"
-            self.error = json.dumps(
-                f"Failed to generate SMIRKS patterns that match both the parent and "
-                f"torsion fragments: {str(e)}"
-            )
-
-            return
+        # # TODO: Move these methods onto the celery worker.
+        # try:
+        #     await self._generate_parameters(
+        #         fragmentation_result=fragmentation_stage.result,
+        #         input_schema=input_schema,
+        #     )
+        # except BaseException as e:  # lgtm [py/catch-base-exception]
+        #
+        #     self.status = "errored"
+        #     self.error = json.dumps(
+        #         f"Failed to generate SMIRKS patterns that match both the parent and "
+        #         f"torsion fragments: {str(e)}"
+        #     )
+        #
+        #     return
 
         # Map the generated QC results into a local QC data class and update the schema
         # to target these.

--- a/openff/bespokefit/executor/services/coordinator/stages.py
+++ b/openff/bespokefit/executor/services/coordinator/stages.py
@@ -496,94 +496,6 @@ class OptimizationStage(_Stage):
         None, description="The result of the optimization."
     )
 
-    # @staticmethod
-    # def _generate_torsion_parameters(
-    #     fragmentation_result: FragmentationResult,
-    #     input_schema: BespokeOptimizationSchema,
-    # ) -> List[ParameterType]:
-    #
-    #     parent = fragmentation_result.parent_molecule
-    #     smirks_gen = SMIRKSGenerator(
-    #         initial_force_field=input_schema.initial_force_field,
-    #         generate_bespoke_terms=input_schema.smirk_settings.generate_bespoke_terms,
-    #         expand_torsion_terms=input_schema.smirk_settings.expand_torsion_terms,
-    #         target_smirks=[SMIRKSType.ProperTorsions],
-    #     )
-    #
-    #     new_smirks = []
-    #     for fragment_data in fragmentation_result.fragments:
-    #         central_bond = fragment_data.bond_indices
-    #         fragment_molecule = fragment_data.molecule
-    #         smirks = smirks_gen.generate_smirks_from_fragment(
-    #             parent=parent,
-    #             fragment=fragment_molecule,
-    #             fragment_map_indices=central_bond,
-    #         )
-    #         new_smirks.extend(smirks)
-    #
-    #     return new_smirks
-    #
-    # @staticmethod
-    # async def _generate_parameters(
-    #     input_schema: BespokeOptimizationSchema,
-    #     fragmentation_result: Optional[FragmentationResult],
-    # ):
-    #     """
-    #     Generate a list of parameters which are to be optimised, these are added to the input force field.
-    #     The parameters are also added to the parameter list in each stage corresponding to the stage where they will be fit.
-    #     """
-    #
-    #     initial_force_field = ForceFieldEditor(input_schema.initial_force_field)
-    #     new_parameters = []
-    #
-    #     target_smirks = {*input_schema.target_smirks}
-    #     if SMIRKSType.ProperTorsions in target_smirks:
-    #         target_smirks.remove(SMIRKSType.ProperTorsions)
-    #
-    #         torsion_parameters = OptimizationStage._generate_torsion_parameters(
-    #             fragmentation_result=fragmentation_result,
-    #             input_schema=input_schema,
-    #         )
-    #         new_parameters.extend(torsion_parameters)
-    #
-    #     if len(target_smirks) > 0:
-    #         smirks_gen = SMIRKSGenerator(
-    #             initial_force_field=input_schema.initial_force_field,
-    #             generate_bespoke_terms=input_schema.smirk_settings.generate_bespoke_terms,
-    #             target_smirks=[*target_smirks],
-    #             smirks_layers=1,
-    #         )
-    #
-    #         parameters = smirks_gen.generate_smirks_from_molecule(
-    #             molecule=input_schema.molecule
-    #         )
-    #         new_parameters.extend(parameters)
-    #
-    #     # add all new terms to the input force field
-    #     initial_force_field.add_parameters(parameters=new_parameters)
-    #
-    #     parameter_to_type = {
-    #         vdWHandler.vdWType: VdWSMIRKS,
-    #         BondHandler.BondType: BondSMIRKS,
-    #         AngleHandler.AngleType: AngleSMIRKS,
-    #         ProperTorsionHandler.ProperTorsionType: ProperTorsionSMIRKS,
-    #         ImproperTorsionHandler.ImproperTorsionType: ImproperTorsionSMIRKS,
-    #     }
-    #     # convert all parameters to bespokefit types
-    #     parameters_to_fit = defaultdict(list)
-    #     for parameter in new_parameters:
-    #         bespoke_parameter = parameter_to_type[parameter.__class__].from_smirnoff(
-    #             parameter
-    #         )
-    #         parameters_to_fit[bespoke_parameter.type].append(bespoke_parameter)
-    #
-    #     # set which parameters should be optimised in each stage
-    #     for stage in input_schema.stages:
-    #         for hyper_param in stage.parameter_hyperparameters:
-    #             stage.parameters.extend(parameters_to_fit[hyper_param.type])
-    #
-    #     input_schema.initial_force_field = initial_force_field.force_field.to_string()
-
     @staticmethod
     async def _inject_bespoke_qc_data(
         qc_generation_stage: QCGenerationStage,
@@ -628,25 +540,6 @@ class OptimizationStage(_Stage):
         completed_stages = {stage.type: stage for stage in task.completed_stages}
 
         input_schema = task.input_schema.copy(deep=True)
-
-        # # Generate all parameters to be optimised
-        # fragmentation_stage: FragmentationStage = completed_stages["fragmentation"]
-
-        # # TODO: Move these methods onto the celery worker.
-        # try:
-        #     await self._generate_parameters(
-        #         fragmentation_result=fragmentation_stage.result,
-        #         input_schema=input_schema,
-        #     )
-        # except BaseException as e:  # lgtm [py/catch-base-exception]
-        #
-        #     self.status = "errored"
-        #     self.error = json.dumps(
-        #         f"Failed to generate SMIRKS patterns that match both the parent and "
-        #         f"torsion fragments: {str(e)}"
-        #     )
-        #
-        #     return
 
         # Map the generated QC results into a local QC data class and update the schema
         # to target these.

--- a/openff/bespokefit/executor/services/coordinator/utils.py
+++ b/openff/bespokefit/executor/services/coordinator/utils.py
@@ -76,5 +76,4 @@ def cache_parameters(
     redis_connection.set(
         hash_string, cached_force_field.to_string(discard_cosmetic_attributes=False)
     )
-    results_schema.json()
     return hash_string

--- a/openff/bespokefit/executor/services/coordinator/utils.py
+++ b/openff/bespokefit/executor/services/coordinator/utils.py
@@ -1,0 +1,80 @@
+import hashlib
+from typing import Optional
+
+import redis
+from openff.toolkit.typing.engines.smirnoff import ForceField
+from openff.toolkit.utils.exceptions import ParameterLookupError
+
+from openff.bespokefit.schema.fitting import BespokeOptimizationSchema
+from openff.bespokefit.schema.results import BespokeOptimizationResults
+
+
+def _hash_fitting_schema(fitting_schema: BespokeOptimizationSchema) -> str:
+    """
+    Create a hash based on the whole fitting schema for any optimised parameters.
+    """
+    hash_string = (
+        fitting_schema.smirk_settings.json() + fitting_schema.initial_force_field_hash
+    )
+    for stage in fitting_schema.stages:
+        # drop the reference data form each target and the parameters from each stage
+        hash_string += stage.json(
+            exclude={"targets": {"__all__": {"reference_data"}}, "parameters": ...}
+        )
+    hash_string = hashlib.sha512(hash_string.encode()).hexdigest()
+    return hash_string
+
+
+def get_cached_parameters(
+    fitting_schema: BespokeOptimizationSchema, redis_connection: redis.Redis
+) -> Optional[ForceField]:
+    """
+    For the given fitting schema create a hash and check for a cached force field which contains a set of fit torsion parameters.
+    """
+    hash_string = _hash_fitting_schema(fitting_schema=fitting_schema)
+
+    cached_ff = redis_connection.get(hash_string)
+    if cached_ff is not None:
+        return ForceField(cached_ff, allow_cosmetic_attributes=True)
+    return None
+
+
+def cache_parameters(
+    results_schema: BespokeOptimizationResults, redis_connection: redis.Redis
+) -> str:
+    """
+    Cache any fitted torsion parameters saved in the final refit force field.
+
+    Returns:
+         The string the parameters are cached under
+    """
+
+    hash_string = _hash_fitting_schema(fitting_schema=results_schema.input_schema)
+    cached_ff = redis_connection.get(hash_string)
+    if cached_ff is not None:
+        cached_force_field = ForceField(cached_ff)
+    else:
+        # create a new blank FF
+        cached_force_field = ForceField()
+
+    torsion_handler_cache = cached_force_field.get_parameter_handler("ProperTorsions")
+    refit_force_field = ForceField(results_schema.refit_force_field)
+    refit_torsions = refit_force_field.get_parameter_handler("ProperTorsions")
+
+    for stage in results_schema.input_schema.stages:
+        for parameter in stage.parameters:
+            try:
+                # the parameter maybe be in more than one stage so only save once
+                _ = torsion_handler_cache[parameter.smirks]
+            except ParameterLookupError:
+                # we need to add the parameter to the cache
+                torsion_handler_cache.add_parameter(
+                    parameter=refit_torsions[parameter.smirks]
+                )
+
+    # now set the force field back in the cache
+    redis_connection.set(
+        hash_string, cached_force_field.to_string(discard_cosmetic_attributes=False)
+    )
+    results_schema.json()
+    return hash_string

--- a/openff/bespokefit/schema/fitting.py
+++ b/openff/bespokefit/schema/fitting.py
@@ -124,6 +124,12 @@ class BespokeOptimizationSchema(BaseOptimizationSchema):
         "parameters for.",
     )
 
+    initial_force_field_hash: str = Field(
+        ...,
+        description="The hash values of the initial input force field with "
+        "no bespokefit modifications. Used for internal hashing",
+    )
+
     fragmentation_engine: Optional[FragmentationEngine] = Field(
         WBOFragmenter(),
         description="The fragmentation engine that should be used to fragment the "

--- a/openff/bespokefit/schema/results.py
+++ b/openff/bespokefit/schema/results.py
@@ -64,6 +64,11 @@ class BaseOptimizationResults(SchemaBase, abc.ABC):
         )
 
     @property
+    def refit_force_field(self) -> str:
+        """Return the final refit force field."""
+        return self.stages[-1].refit_force_field
+
+    @property
     def refit_parameter_values(
         self,
     ) -> Optional[Dict[BaseSMIRKSParameter, Dict[str, unit.Quantity]]]:

--- a/openff/bespokefit/schema/targets.py
+++ b/openff/bespokefit/schema/targets.py
@@ -29,6 +29,10 @@ class BaseTargetSchema(SchemaBase, abc.ABC):
 
     reference_data: Optional[Union[Any, LocalQCData[Any], BespokeQCData[Any]]]
 
+    calculation_specification: Optional[
+        Union[Torsion1DTaskSpec, HessianTaskSpec, OptimizationTaskSpec]
+    ]
+
     extras: Dict[str, str] = Field(
         {},
         description="Extra settings to use for the target. Optimizer specific settings "
@@ -63,6 +67,10 @@ class TorsionProfileTargetSchema(BaseTargetSchema):
         description="The reference QC data (either existing or to be generated on the "
         "fly) to fit against.",
     )
+    calculation_specification: Optional[Torsion1DTaskSpec] = Field(
+        None,
+        description="The specification for the reference torsion drive calculation, also acts as a provenance source.",
+    )
 
     attenuate_weights: bool = Field(
         True, description="Whether to attenuate the weights as a function of energy."
@@ -94,7 +102,10 @@ class AbInitioTargetSchema(BaseTargetSchema):
         description="The reference QC data (either existing or to be generated on the "
         "fly) to fit against.",
     )
-
+    calculation_specification: Optional[Torsion1DTaskSpec] = Field(
+        None,
+        description="The specification for the reference torsion drive calculation, also acts as a provenance source.",
+    )
     attenuate_weights: bool = Field(
         False, description="Whether to attenuate the weights as a function of energy."
     )
@@ -128,6 +139,10 @@ class VibrationTargetSchema(BaseTargetSchema):
         description="The reference QC data (either existing or to be generated on the "
         "fly) to fit against.",
     )
+    calculation_specification: Optional[HessianTaskSpec] = Field(
+        None,
+        description="The specification for the reference hessian calculation, also acts as a provenance source.",
+    )
 
     mode_reassignment: Optional[Literal["permute", "overlap"]] = Field(
         None, description="The (optional) method by which to re-assign normal modes."
@@ -154,7 +169,10 @@ class OptGeoTargetSchema(BaseTargetSchema):
         description="The reference QC data (either existing or to be generated on the "
         "fly) to fit against.",
     )
-
+    calculation_specification: Optional[OptimizationTaskSpec] = Field(
+        None,
+        description="The specification for the reference optimisation calculation, also acts as a provenance source.",
+    )
     bond_denominator: float = Field(
         0.05,
         description="The denominator to scale the contributions of bonds to the "

--- a/openff/bespokefit/tests/executor/services/conftest.py
+++ b/openff/bespokefit/tests/executor/services/conftest.py
@@ -1,3 +1,5 @@
+import hashlib
+
 import pytest
 from openff.fragmenter.fragment import Fragment, FragmentationResult
 
@@ -47,10 +49,11 @@ def ptp1b_input_schema_single(ptp1b_smiles) -> BespokeOptimizationSchema:
     """
 
     force_field = ForceFieldEditor("openff_unconstrained-1.3.0.offxml")
-
+    ff_hash = hashlib.sha512(force_field.force_field.to_string().encode()).hexdigest()
     return BespokeOptimizationSchema(
         id="ptp1b",
         initial_force_field=force_field.force_field.to_string(),
+        initial_force_field_hash=ff_hash,
         stages=[
             OptimizationStageSchema(
                 optimizer=ForceBalanceSchema(),

--- a/openff/bespokefit/tests/executor/services/coordinator/test_models.py
+++ b/openff/bespokefit/tests/executor/services/coordinator/test_models.py
@@ -1,6 +1,8 @@
+import hashlib
 from typing import List, Optional
 
 import pytest
+from openff.toolkit.typing.engines.smirnoff import ForceField
 
 from openff.bespokefit.executor.services.coordinator.models import (
     CoordinatorGETResponse,
@@ -28,11 +30,15 @@ def mock_task(
     completed_stages: List[StageType],
 ) -> CoordinatorTask:
 
+    force_field = ForceField("openff_unconstrained-1.0.0.offxml")
+    ff_hash = hashlib.sha512(force_field.to_string().encode()).hexdigest()
+
     return CoordinatorTask(
         id="mock-task-id",
         input_schema=BespokeOptimizationSchema(
             smiles="C",
-            initial_force_field="openff-1.0.0.offxml",
+            initial_force_field="openff_unconstrained-1.0.0.offxml",
+            initial_force_field_hash=ff_hash,
             target_torsion_smirks=[],
             stages=[
                 OptimizationStageSchema(

--- a/openff/bespokefit/tests/executor/services/coordinator/test_utils.py
+++ b/openff/bespokefit/tests/executor/services/coordinator/test_utils.py
@@ -1,0 +1,71 @@
+from openff.toolkit.typing.engines.smirnoff import ForceField
+
+from openff.bespokefit.executor.services.coordinator.utils import (
+    _hash_fitting_schema,
+    cache_parameters,
+    get_cached_parameters,
+)
+from openff.bespokefit.schema.smirnoff import ProperTorsionSMIRKS
+
+
+def test_hash_fitting_schema(ptp1b_input_schema_single):
+    """
+    Test hashing a fitting schema for caching.
+    """
+    normal_hash = _hash_fitting_schema(fitting_schema=ptp1b_input_schema_single)
+    # add a parameter to fit and rehash, should not change the hash
+    ptp1b_input_schema_single.stages[0].parameters.append(
+        ProperTorsionSMIRKS(smirks="[*:1]-[#6:2]-[#6:3]-[*:4]", attributes={"k1"})
+    )
+    assert normal_hash == _hash_fitting_schema(fitting_schema=ptp1b_input_schema_single)
+
+    # now change a setting and rehash, this should change the hash
+    ptp1b_input_schema_single.smirk_settings.expand_torsion_terms = False
+    assert normal_hash != _hash_fitting_schema(fitting_schema=ptp1b_input_schema_single)
+
+
+def test_get_cached_parameters(redis_connection, ptp1b_input_schema_single):
+    """
+    Test querying redis for cached parameters
+    """
+
+    # try and get some parameters from redis after not storing
+    force_field = get_cached_parameters(
+        fitting_schema=ptp1b_input_schema_single, redis_connection=redis_connection
+    )
+    assert force_field is None
+    # now store some parameters under this hash
+    openff_ff = ForceField("openff-1.0.0.offxml")
+    redis_connection.set(
+        _hash_fitting_schema(ptp1b_input_schema_single), openff_ff.to_string()
+    )
+
+    cached_ff = get_cached_parameters(
+        fitting_schema=ptp1b_input_schema_single, redis_connection=redis_connection
+    )
+
+    assert cached_ff.__hash__() == openff_ff.__hash__()
+
+
+def test_cache_parameters(bespoke_optimization_results, redis_connection):
+    """
+    Test adding fitted parameters to a redis cache.
+    """
+    # create a blank cache for the forcefield
+    hash_string = cache_parameters(
+        results_schema=bespoke_optimization_results, redis_connection=redis_connection
+    )
+    force_field = ForceField(redis_connection.get(hash_string))
+    # we should have nothing saved.
+    assert len(force_field.get_parameter_handler("ProperTorsions").parameters) == 0
+    # add a mock parameter to signify it has been fit and cache again
+    bespoke_optimization_results.input_schema.stages[0].parameters.append(
+        ProperTorsionSMIRKS(smirks="[*:1]~[#6X3:2]-[#6X3:3]~[*:4]", attributes={"k1"})
+    )
+    cache_parameters(
+        results_schema=bespoke_optimization_results, redis_connection=redis_connection
+    )
+    # grab the force field again and make sure we have a parameter saved
+    force_field = ForceField(redis_connection.get(hash_string))
+    # we should have nothing saved.
+    assert len(force_field.get_parameter_handler("ProperTorsions").parameters) == 1

--- a/openff/bespokefit/tests/executor/services/coordinator/test_workers.py
+++ b/openff/bespokefit/tests/executor/services/coordinator/test_workers.py
@@ -48,6 +48,7 @@ async def test_internal_cycle(redis_connection, monkeypatch):
         input_schema=BespokeOptimizationSchema(
             smiles="CC",
             initial_force_field="openff-2.0.0.offxml",
+            initial_force_field_hash="test_hash",
             target_torsion_smirks=[],
             stages=[
                 OptimizationStageSchema(

--- a/openff/bespokefit/tests/executor/services/optimizer/test_app.py
+++ b/openff/bespokefit/tests/executor/services/optimizer/test_app.py
@@ -52,6 +52,7 @@ def test_post_optimize(optimizer_client, redis_connection, monkeypatch):
     input_schema = BespokeOptimizationSchema(
         smiles="CC",
         initial_force_field="openff-2.0.0.offxml",
+        initial_force_field_hash="test_hash",
         target_torsion_smirks=[],
         stages=[
             OptimizationStageSchema(

--- a/openff/bespokefit/tests/executor/services/optimizer/test_worker.py
+++ b/openff/bespokefit/tests/executor/services/optimizer/test_worker.py
@@ -67,3 +67,16 @@ def test_optimize(monkeypatch):
     assert result.status == expected_output.status
 
     assert received_schema.json() == input_schema.stages[0].json()
+
+
+def test_optimise_cache(bespoke_optimization_schema):
+    """
+    Make sure any stages with cached parameters are skipped and a mock result is returned.
+    """
+
+    result_json = worker.optimize(
+        optimization_input_json=bespoke_optimization_schema.json()
+    )
+    result = BespokeOptimizationResults.parse_raw(result_json)
+    assert result.status == "success"
+    assert result.stages[0].provenance["skipped"] == "True"

--- a/openff/bespokefit/tests/executor/services/optimizer/test_worker.py
+++ b/openff/bespokefit/tests/executor/services/optimizer/test_worker.py
@@ -13,6 +13,7 @@ from openff.bespokefit.schema.results import (
     BespokeOptimizationResults,
     OptimizationStageResults,
 )
+from openff.bespokefit.schema.smirnoff import ProperTorsionSMIRKS
 
 
 def test_optimize(monkeypatch):
@@ -21,10 +22,15 @@ def test_optimize(monkeypatch):
         id="test",
         smiles="CC",
         initial_force_field="openff-2.0.0.offxml",
+        initial_force_field_hash="test_hash",
         target_torsion_smirks=[],
         stages=[
             OptimizationStageSchema(
-                parameters=[],
+                parameters=[
+                    ProperTorsionSMIRKS(
+                        smirks="[*:1]-[#6:2]-[#6:3]-[*:4]", attributes={"k1"}
+                    )
+                ],
                 parameter_hyperparameters=[],
                 targets=[],
                 optimizer=ForceBalanceSchema(max_iterations=1),

--- a/openff/bespokefit/tests/executor/services/test_stages.py
+++ b/openff/bespokefit/tests/executor/services/test_stages.py
@@ -1,7 +1,7 @@
 import pytest
 from openff.toolkit.typing.engines.smirnoff import ForceField
 
-from openff.bespokefit.executor.services.coordinator.stages import OptimizationStage
+from openff.bespokefit.executor.services.coordinator.stages import QCGenerationStage
 
 
 def test_generate_torsions(ptp1b_fragment, ptp1b_input_schema_single):
@@ -9,18 +9,18 @@ def test_generate_torsions(ptp1b_fragment, ptp1b_input_schema_single):
     Make sure the optimisation stage can correctly regenerate torsion SMIRKS which hit both the parent and fragment molecule.
     """
     input_schema = ptp1b_input_schema_single.copy(deep=True)
-    new_parameter = OptimizationStage._generate_torsion_parameters(
+    new_parameters, _ = QCGenerationStage._generate_torsion_parameters(
         fragmentation_result=ptp1b_fragment, input_schema=input_schema
     )[0]
     # now check the new smirks hits the fragment and parent, for the same atoms
     parent_matches = set(
         ptp1b_fragment.parent_molecule.chemical_environment_matches(
-            new_parameter.smirks
+            new_parameters.smirks
         )
     )
     fragment_matches = set(
         ptp1b_fragment.fragments[0].molecule.chemical_environment_matches(
-            new_parameter.smirks
+            new_parameters.smirks
         )
     )
     # check number of unique matches is the same
@@ -33,7 +33,7 @@ async def test_generate_parameters(ptp1b_input_schema_single, ptp1b_fragment):
     Make sure that old parameters are generated for the stage
     """
     input_schema = ptp1b_input_schema_single.copy(deep=True)
-    await OptimizationStage._generate_parameters(
+    await QCGenerationStage._generate_parameters(
         fragmentation_result=ptp1b_fragment, input_schema=input_schema
     )
     # make sure we have new parameters
@@ -69,7 +69,7 @@ async def test_generate_parameters_multiple_stages(
 ):
     """Make sure parameters are correctly generated and assigned to the correct optimisation stage."""
     input_schema = ptp1b_input_schema_multiple.copy(deep=True)
-    await OptimizationStage._generate_parameters(
+    await QCGenerationStage._generate_parameters(
         fragmentation_result=ptp1b_fragment, input_schema=input_schema
     )
     force_field = ForceField(

--- a/openff/bespokefit/utilities/smirnoff.py
+++ b/openff/bespokefit/utilities/smirnoff.py
@@ -91,20 +91,24 @@ class ForceFieldEditor:
 
             for i, parameter in enumerate(handler_parameters, start=2):
 
-                parameter_data = parameter.to_dict()
+                parameter_data = parameter.to_dict(discard_cosmetic_attributes=False)
 
                 try:
                     current_param = current_params[parameter_data["smirks"]]
                     parameter_data["id"] = current_param.id
                     # update the parameter using the init to get around conditional
                     # assigment
-                    current_param.__init__(**parameter_data)
+                    current_param.__init__(
+                        **parameter_data, allow_cosmetic_attributes=True
+                    )
                 except ParameterLookupError:
                     parameter_data["id"] = _smirks_ids[parameter.__class__] + str(
                         n_params + i
                     )
 
-                    current_param = parameter.__class__(**parameter_data)
+                    current_param = parameter.__class__(
+                        **parameter_data, allow_cosmetic_attributes=True
+                    )
                     current_params.append(current_param)
 
                 added_parameters.append(current_param)


### PR DESCRIPTION
## Description
This PR reworks the coordinator stages to allow for torsion parameter caching in redis. 

Parameters are hashed based on:
- initial force field
- smirks generation settings
- optimiser settings
- targets and settings 
- the qc calculation specification

The new workflow:
- molecules are fragmented
- bespoke torsion parameters generated to match the fragment and parent
- parameter cache is checked, reusable parameters are those which match the same atoms in the fragment as the new bespoke pattern. Cached values are then combined with new smirks to ensure the pattern matches the fragment and new parent
- QM jobs for cached parameters are dropped
- workflow continues as normal

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Add tests
  - [ ] add regression test 

## Questions
- [ ] 

## Status
- [ ] Ready to go