### PR TITLE
Add SMILES to executor list CLI

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -119,7 +119,13 @@ used to check on state of the submission:
 openff-bespoke executor watch --id "1"
 ```
 
-and once finished, the final force field can be retrieved using the `retrieve` command:
+A full list of submissions currently being processes can be printed with the `list` command:
+
+```shell
+openff-bespoke executor list
+```
+
+Once finished, the final force field can be retrieved using the `retrieve` command:
 
 ```shell
 openff-bespoke executor retrieve --id          "1"                   \

--- a/openff/bespokefit/executor/services/coordinator/models.py
+++ b/openff/bespokefit/executor/services/coordinator/models.py
@@ -71,6 +71,12 @@ class CoordinatorGETStageStatus(BaseModel):
 
 class CoordinatorGETResponse(Link):
 
+    smiles: str = Field(
+        ...,
+        description="The SMILES representation of the molecule that the bespoke "
+        "parameters are being generated for.",
+    )
+
     stages: List[CoordinatorGETStageStatus] = Field(
         ..., description="The stages of the bespoke optimization."
     )
@@ -102,6 +108,7 @@ class CoordinatorGETResponse(Link):
                 f"{settings.BEFLOW_API_V1_STR}/"
                 f"{settings.BEFLOW_COORDINATOR_PREFIX}/{task.id}"
             ),
+            smiles=task.input_schema.smiles,
             stages=stage_responses,
             results=(
                 None

--- a/openff/bespokefit/tests/cli/executor/test_list.py
+++ b/openff/bespokefit/tests/cli/executor/test_list.py
@@ -1,12 +1,39 @@
 import pytest
 import requests_mock
+import rich
 
-from openff.bespokefit.cli.executor.list import list_cli
+from openff.bespokefit.cli.executor.list import _get_smiles, list_cli
 from openff.bespokefit.executor.services import settings
 from openff.bespokefit.executor.services.coordinator.models import (
     CoordinatorGETPageResponse,
+    CoordinatorGETResponse,
 )
 from openff.bespokefit.executor.services.models import Link
+
+
+def test_get_smiles():
+
+    with requests_mock.Mocker() as m:
+
+        mock_response = CoordinatorGETResponse(
+            self="self-page",
+            id="1",
+            smiles="[C:1]([H:2])([H:3])=[C:4]([H:5])[H:6]",
+            stages=[],
+        )
+
+        m.get(
+            (
+                f"http://127.0.0.1:"
+                f"{settings.BEFLOW_GATEWAY_PORT}"
+                f"{settings.BEFLOW_API_V1_STR}/"
+                f"{settings.BEFLOW_COORDINATOR_PREFIX}/1"
+            ),
+            text=mock_response.json(by_alias=True),
+        )
+
+        smiles = _get_smiles(rich.get_console(), "1")
+        assert smiles == "C=C"
 
 
 @pytest.mark.parametrize(
@@ -23,7 +50,6 @@ def test_list_cli(n_results, expected_message, runner):
                 Link(id=f"{i}", self=f"self-{i}") for i in range(1, 1 + n_results)
             ],
         )
-
         m.get(
             (
                 f"http://127.0.0.1:"
@@ -33,6 +59,22 @@ def test_list_cli(n_results, expected_message, runner):
             ),
             text=mock_response.json(),
         )
+        for i in range(1, n_results + 1):
+            mock_response = CoordinatorGETResponse(
+                self="self-page",
+                id=str(i),
+                smiles="[C:1]([H:2])([H:3])=[C:4]([H:5])[H:6]",
+                stages=[],
+            )
+            m.get(
+                (
+                    f"http://127.0.0.1:"
+                    f"{settings.BEFLOW_GATEWAY_PORT}"
+                    f"{settings.BEFLOW_API_V1_STR}/"
+                    f"{settings.BEFLOW_COORDINATOR_PREFIX}/{i}"
+                ),
+                text=mock_response.json(by_alias=True),
+            )
 
         output = runner.invoke(list_cli)
         assert output.exit_code == 0

--- a/openff/bespokefit/tests/cli/executor/test_retrieve.py
+++ b/openff/bespokefit/tests/cli/executor/test_retrieve.py
@@ -26,6 +26,7 @@ def _mock_coordinator_get(status, results=None):
         mock_response = CoordinatorGETResponse(
             id="1",
             self="",
+            smiles="CC",
             stages=[
                 CoordinatorGETStageStatus(
                     type="fragmentation", status=status, error=None, results=None

--- a/openff/bespokefit/tests/cli/executor/test_run.py
+++ b/openff/bespokefit/tests/cli/executor/test_run.py
@@ -40,6 +40,7 @@ def test_run(runner, tmpdir):
             text=CoordinatorGETResponse(
                 id="1",
                 self="",
+                smiles="CC",
                 stages=[
                     CoordinatorGETStageStatus(
                         type="fragmentation", status="success", error=None, results=None

--- a/openff/bespokefit/tests/cli/executor/test_watch.py
+++ b/openff/bespokefit/tests/cli/executor/test_watch.py
@@ -22,6 +22,7 @@ def test_watch(runner):
         mock_response = CoordinatorGETResponse(
             id="1",
             self=mock_href,
+            smiles="CC",
             stages=[
                 CoordinatorGETStageStatus(
                     type="fragmentation", status="success", error=None, results=None

--- a/openff/bespokefit/tests/executor/services/coordinator/test_models.py
+++ b/openff/bespokefit/tests/executor/services/coordinator/test_models.py
@@ -115,6 +115,7 @@ def test_get_status_from_stage(stage, expected):
             CoordinatorGETResponse(
                 id="mock-task-id",
                 self="",
+                smiles="CC",
                 stages=[],
                 results=results,
             ),

--- a/openff/bespokefit/tests/executor/test_executor.py
+++ b/openff/bespokefit/tests/executor/test_executor.py
@@ -35,6 +35,7 @@ def mock_get_response(stage_status="running") -> CoordinatorGETResponse:
     mock_response = CoordinatorGETResponse(
         id=mock_id,
         self=mock_href,
+        smiles="CC",
         stages=[
             CoordinatorGETStageStatus(
                 type="fragmentation", status=stage_status, error=None, results=None
@@ -165,6 +166,7 @@ class TestBespokeExecutorOutput:
             CoordinatorGETResponse(
                 id="mock-id",
                 self="",
+                smiles="CC",
                 stages=[
                     CoordinatorGETStageStatus(
                         type="fragmentation", status="running", error=None, results=None
@@ -340,6 +342,7 @@ def test_query_coordinator():
     mock_response = CoordinatorGETResponse(
         id="mock-id",
         self="",
+        smiles="CC",
         stages=[
             CoordinatorGETStageStatus(
                 type="fragmentation", status="running", error=None, results=None
@@ -375,6 +378,7 @@ def test_wait_for_stage(status):
     mock_response = CoordinatorGETResponse(
         id="mock-id",
         self="",
+        smiles="CC",
         stages=[
             CoordinatorGETStageStatus(
                 type="fragmentation", status="running", error=None, results=None


### PR DESCRIPTION
## Description

This PR enhances the executor `list` CLI command by including both the ID and SMILES associated with the ID in a formatted table, rather than just printing a plain list of IDs.

## Status
- [X] Ready to go