### PR TITLE
Use OpenFF 2.0.0 by default in bespoke workflows

### DIFF
--- a/openff/bespokefit/data/schemas/default.json
+++ b/openff/bespokefit/data/schemas/default.json
@@ -24,6 +24,7 @@
     {
       "weight": 1.0,
       "reference_data": null,
+      "calculation_specification": null,
       "extras": {},
       "type": "TorsionProfile",
       "attenuate_weights": true,

--- a/openff/bespokefit/tests/cli/executor/test_submit.py
+++ b/openff/bespokefit/tests/cli/executor/test_submit.py
@@ -22,6 +22,28 @@ from openff.bespokefit.executor.services.coordinator.models import (
 )
 from openff.bespokefit.schema.fitting import BespokeOptimizationSchema
 from openff.bespokefit.tests import does_not_raise
+from openff.bespokefit.workflows import BespokeWorkflowFactory
+
+
+def test_default_spec_up_to_date():
+
+    current_default_spec = BespokeWorkflowFactory().json(sort_keys=True, indent=2)
+
+    with open(
+        get_data_file_path(os.path.join("schemas", "default.json"), "openff.bespokefit")
+    ) as file:
+
+        default_spec_from_file = json.dumps(json.load(file), sort_keys=True, indent=2)
+
+    assert current_default_spec == default_spec_from_file
+
+    # with open(
+    #     get_data_file_path(
+    #         os.path.join("schemas", "default.json"), "openff.bespokefit"
+    #     ),
+    #     "w",
+    # ) as file:
+    #     file.write(BespokeWorkflowFactory().json(indent=2))
 
 
 @pytest.mark.parametrize(

--- a/openff/bespokefit/workflows/bespoke.py
+++ b/openff/bespokefit/workflows/bespoke.py
@@ -74,7 +74,7 @@ class BespokeWorkflowFactory(ClassBase):
     """
 
     initial_force_field: str = Field(
-        "openff_unconstrained-1.3.0.offxml",
+        "openff_unconstrained-2.0.0.offxml",
         description="The name of the unconstrained force field to use as a starting "
         "point for optimization. The force field must be conda installed.",
     )


### PR DESCRIPTION
## Description

This PR updates the workflow factory to use OpenFF 2.0.0 by default.

## Status
- [X] Ready to go