### PR TITLE
Move force field CLI arg to 'spec overrides'

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -47,7 +47,6 @@ It will accept either a SMILES pattern
 
 ```shell
 openff-bespoke executor run --smiles             "CC(=O)NC1=CC=C(C=C1)O" \
-                            --force-field        "openff-2.0.0.offxml"   \
                             --spec               "default"               \
                             --output             "acetaminophen.json"    \
                             --output-force-field "acetaminophen.offxml"  \
@@ -59,7 +58,6 @@ or the path to an SDF file
 
 ```shell
 openff-bespoke executor run --file               "acetaminophen.sdf"    \
-                            --force-field        "openff-2.0.0.offxml"  \
                             --spec               "default"              \
                             --output             "acetaminophen.json"   \
                             --output-force-field "acetaminophen.offxml" \
@@ -80,7 +78,6 @@ however extra processes can easily be requested to speed up the process:
 
 ```shell
 openff-bespoke executor run --file                 "acetaminophen.sdf"   \
-                            --force-field          "openff-2.0.0.offxml" \
                             --spec                 "default"             \ 
                             --n-qc-compute-workers 2                     \
                             --qc-compute-n-cores   8
@@ -114,7 +111,6 @@ the `submit` command either in the form of a SMILES pattern:
 
 ```shell
 openff-bespoke executor submit --smiles      "CC(=O)NC1=CC=C(C=C1)O" \
-                               --force-field "openff-2.0.0.offxml"   \
                                --spec        "default"
 ```
 
@@ -122,7 +118,6 @@ or loading the molecule from an SDF (or similar) file:
 
 ```shell
 openff-bespoke executor submit --file        "acetaminophen.sdf"   \
-                               --force-field "openff-2.0.0.offxml" \
                                --spec        "default"
 ```
 
@@ -143,8 +138,7 @@ Once finished, the final force field can be retrieved using the `retrieve` comma
 
 ```shell
 openff-bespoke executor retrieve --id          "1"                   \
-                                 --output      "acetaminophen.json"  \
-                                 --force-field "acetaminophen.offxml"
+                                 --output      "acetaminophen.json"
 ```
 
 See the [results chapter](bespoke_results_chapter) for more details on retrieving the results of a bespoke fit.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -69,8 +69,8 @@ Here we have specified that we wish to start the fit from the general OpenFF 2.0
 it with bespoke parameters generated according to the [default built-in workflow](workflow_chapter). 
 
 :::{note}
-Other available specifications can be viewed by running `openff-bespoke executor run --help`, or alternatively the 
-path to a [saved workflow factory](quick_start_config_factory) can also be provided using the `--spec-file` flag.
+Other available workflow specifications can be viewed by running `openff-bespoke executor run --help`, or alternatively 
+the path to a [saved workflow factory](quick_start_config_factory) can also be provided using the `--spec-file` flag.
 :::
 
 By default, BespokeFit will use only a single process for each step in the fitting workflow (e.g. generating QC data),

--- a/openff/bespokefit/cli/executor/submit.py
+++ b/openff/bespokefit/cli/executor/submit.py
@@ -45,23 +45,23 @@ def submit_options():
             "--spec",
             "spec_name",
             type=click.Choice(choices=["default", "debug"], case_sensitive=False),
-            help="The name of the built-in configuration to use",
+            help="The name of the built-in bespoke workflow specification to use.",
             required=False,
         ),
         click.option(
             "--spec-file",
             "spec_file_name",
             type=click.Path(exists=False, file_okay=True, dir_okay=False),
-            help="The path to a serialized bespoke workflow factory",
+            help="The path to a serialized bespoke workflow factory that encodes the "
+            "bespoke workflow to use.",
             required=False,
         ),
-        optgroup.group("Specification overrides"),
+        optgroup.group("Workflow overrides"),
         optgroup.option(
             "--force-field",
             "force_field_path",
             type=click.Path(exists=False, file_okay=True, dir_okay=False),
-            help="The initial force field to build upon. This will overwrite the value "
-            "in the workflow spec if provided.",
+            help="A custom initial force field to start the bespoke fits from.",
             default=None,
             show_default=True,
             required=False,

--- a/openff/bespokefit/cli/executor/submit.py
+++ b/openff/bespokefit/cli/executor/submit.py
@@ -42,6 +42,21 @@ def submit_options():
             required=False,
         ),
         click.option(
+            "--spec",
+            "spec_name",
+            type=click.Choice(choices=["default", "debug"], case_sensitive=False),
+            help="The name of the built-in configuration to use",
+            required=False,
+        ),
+        click.option(
+            "--spec-file",
+            "spec_file_name",
+            type=click.Path(exists=False, file_okay=True, dir_okay=False),
+            help="The path to a serialized bespoke workflow factory",
+            required=False,
+        ),
+        optgroup.group("Specification overrides"),
+        optgroup.option(
             "--force-field",
             "force_field_path",
             type=click.Path(exists=False, file_okay=True, dir_okay=False),
@@ -49,21 +64,6 @@ def submit_options():
             "in the workflow spec if provided.",
             default=None,
             show_default=True,
-            required=False,
-        ),
-        optgroup.group("Optimization configuration"),
-        optgroup.option(
-            "--spec",
-            "spec_name",
-            type=click.Choice(choices=["default", "debug"], case_sensitive=False),
-            help="The name of the built-in configuration to use",
-            required=False,
-        ),
-        optgroup.option(
-            "--spec-file",
-            "spec_file_name",
-            type=click.Path(exists=False, file_okay=True, dir_okay=False),
-            help="The path to a serialized bespoke workflow factory",
             required=False,
         ),
     ]


### PR DESCRIPTION
## Description

This PR moves the input force field argument into a new `Workflow overrides` argument group to make clear that it is overriding an option in the workflow specification.

In future we could consider exposing multiple such arguments, such as overriding the fragmentation scheme or QC method, via the CLI to allow easier experimentation.

## Status
- [X] Ready to go