### PR TITLE
Fix refit force field stored after error

### DIFF
--- a/openff/bespokefit/cli/executor/run.py
+++ b/openff/bespokefit/cli/executor/run.py
@@ -97,7 +97,7 @@ def _run_cli(
                     Padding(
                         f"the bespoke force field has been saved to "
                         f"[repr.filename]{output_force_field_path}[/repr.filename]",
-                        (1, 0, 1, 0),
+                        (0, 0, 1, 0),
                     )
                 )
 

--- a/openff/bespokefit/executor/executor.py
+++ b/openff/bespokefit/executor/executor.py
@@ -101,14 +101,12 @@ class BespokeExecutorOutput(BaseModel):
     @property
     def bespoke_force_field(self) -> Optional[ForceField]:
         """The final bespoke force field if the bespoke fitting workflow is complete."""
-        return (
-            None
-            if self.results is None
-            else (
-                ForceField(
-                    self.results.refit_force_field, allow_cosmetic_attributes=True
-                )
-            )
+
+        if self.results is None or self.results.refit_force_field is None:
+            return None
+
+        return ForceField(
+            self.results.refit_force_field, allow_cosmetic_attributes=True
         )
 
     @property

--- a/openff/bespokefit/executor/services/optimizer/worker.py
+++ b/openff/bespokefit/executor/services/optimizer/worker.py
@@ -49,7 +49,8 @@ def optimize(self, optimization_input_json: str) -> str:
         for i, stage in enumerate(input_schema.stages):
 
             optimizer = get_optimizer(stage.optimizer.type)
-            # If there are no parameters to optimise as they have all been cached mock the result
+            # If there are no parameters to optimise as they have all been cached mock
+            # the result
             if not stage.parameters:
                 result = OptimizationStageResults(
                     provenance={"skipped": True},
@@ -70,13 +71,22 @@ def optimize(self, optimization_input_json: str) -> str:
             stage_results.append(result)
 
             if result.status != "success":
-                break
+
+                raise (
+                    RuntimeError("an unknown error occurred")
+                    if result.error is None
+                    else RuntimeError(
+                        f"{result.error.type}: "
+                        f"{result.error.message}\n{result.error.traceback}"
+                    )
+                )
 
             input_force_field = ForceField(
                 ForceField(
                     result.refit_force_field, allow_cosmetic_attributes=True
                 ).to_string(discard_cosmetic_attributes=True)
             )
+
         if settings.BEFLOW_OPTIMIZER_KEEP_FILES:
             os.makedirs(os.path.join(home, input_schema.id), exist_ok=True)
             shutil.move(os.getcwd(), os.path.join(home, input_schema.id))

--- a/openff/bespokefit/optimizers/forcebalance/factories.py
+++ b/openff/bespokefit/optimizers/forcebalance/factories.py
@@ -21,7 +21,6 @@ from qcelemental.models.procedures import OptimizationResult, TorsionDriveResult
 from qcportal.models import TorsionDriveRecord
 from qcportal.models.records import OptimizationRecord, RecordBase, ResultRecord
 from simtk import unit
-from tqdm import tqdm
 
 from openff.bespokefit.exceptions import OptimizerError, QCRecordMissMatchError
 from openff.bespokefit.optimizers.forcebalance.templates import (
@@ -247,9 +246,9 @@ class _TargetFactory(Generic[T], abc.ABC):
 
         target_batches = cls._batch_qc_records(target, qc_records)
 
-        for target_name, target_records in tqdm(target_batches.items()):
+        for target_name, target_records in target_batches.items():
 
-            tqdm.write(f"generating target directory for {target_name}")
+            print(f"generating target directory for {target_name}")
 
             target_directory = os.path.join(root_directory, target_name)
             os.makedirs(target_directory, exist_ok=True)

--- a/openff/bespokefit/optimizers/forcebalance/forcebalance.py
+++ b/openff/bespokefit/optimizers/forcebalance/forcebalance.py
@@ -140,7 +140,9 @@ class ForceBalanceOptimizer(BaseOptimizer):
             provenance=cls.provenance(),
             status=results_dictionary["status"],
             error=results_dictionary["error"],
-            refit_force_field=force_field_editor.force_field.to_string(
+            refit_force_field=None
+            if results_dictionary["error"] is not None
+            else force_field_editor.force_field.to_string(
                 discard_cosmetic_attributes=True
             ),
         )

--- a/openff/bespokefit/schema/results.py
+++ b/openff/bespokefit/schema/results.py
@@ -64,9 +64,12 @@ class BaseOptimizationResults(SchemaBase, abc.ABC):
         )
 
     @property
-    def refit_force_field(self) -> str:
+    def refit_force_field(self) -> Optional[str]:
         """Return the final refit force field."""
-        return self.stages[-1].refit_force_field
+
+        return (
+            None if not self.status == "success" else self.stages[-1].refit_force_field
+        )
 
     @property
     def refit_parameter_values(
@@ -74,9 +77,7 @@ class BaseOptimizationResults(SchemaBase, abc.ABC):
     ) -> Optional[Dict[BaseSMIRKSParameter, Dict[str, unit.Quantity]]]:
         """A list of the refit force field parameters."""
 
-        if self.input_schema is None or len(self.stages) != len(
-            self.input_schema.stages
-        ):
+        if self.input_schema is None or not self.status == "success":
             return None
 
         refit_force_field = ForceField(self.stages[-1].refit_force_field)

--- a/openff/bespokefit/tests/executor/services/optimizer/test_worker.py
+++ b/openff/bespokefit/tests/executor/services/optimizer/test_worker.py
@@ -1,6 +1,7 @@
 import json
 
 from openff.fragmenter.fragment import WBOFragmenter
+from openff.toolkit.typing.engines.smirnoff import ForceField
 
 from openff.bespokefit.executor.services.optimizer import worker
 from openff.bespokefit.optimizers import ForceBalanceOptimizer
@@ -28,7 +29,7 @@ def test_optimize(monkeypatch):
             OptimizationStageSchema(
                 parameters=[
                     ProperTorsionSMIRKS(
-                        smirks="[*:1]-[#6:2]-[#6:3]-[*:4]", attributes={"k1"}
+                        smirks="[*:1]-[#6X4:2]-[#6X4:3]-[*:4]", attributes={"k1"}
                     )
                 ],
                 parameter_hyperparameters=[],
@@ -42,7 +43,13 @@ def test_optimize(monkeypatch):
 
     expected_output = BespokeOptimizationResults(
         input_schema=input_schema,
-        stages=[OptimizationStageResults(provenance={}, status="running")],
+        stages=[
+            OptimizationStageResults(
+                provenance={},
+                status="success",
+                refit_force_field=ForceField("openff-2.0.0.offxml").to_string(),
+            )
+        ],
     )
 
     received_schema = None


### PR DESCRIPTION
## Description

This PR fixes a bug whereby the optimiser stage would incorrectly store a 'refit' force field even after the optimisation errored out. This would ultimately make it look like the bespoke fit succeed even though it failed.

Sneaked in here also is a fix for the semaphore leak caused by `tqdm`.

## Status
- [X] Ready to go