### PR TITLE
Replace `settings` variable with function

### DIFF
--- a/openff/bespokefit/cli/cache.py
+++ b/openff/bespokefit/cli/cache.py
@@ -24,7 +24,7 @@ from openff.bespokefit.cli.utilities import (
     exit_with_messages,
     print_header,
 )
-from openff.bespokefit.executor.services import settings
+from openff.bespokefit.executor.services import current_settings
 from openff.bespokefit.executor.services.qcgenerator.cache import _canonicalize_task
 from openff.bespokefit.executor.utilities.redis import is_redis_available, launch_redis
 from openff.bespokefit.schema.data import LocalQCData
@@ -159,6 +159,8 @@ def _update(
         )
 
     console.print(Padding("2. connecting to redis cache", (1, 0, 1, 0)))
+
+    settings = current_settings()
 
     if launch_redis_if_unavailable and not is_redis_available(
         host=settings.BEFLOW_REDIS_ADDRESS, port=settings.BEFLOW_REDIS_PORT

--- a/openff/bespokefit/cli/executor/list.py
+++ b/openff/bespokefit/cli/executor/list.py
@@ -41,11 +41,13 @@ def list_cli():
     console = rich.get_console()
     print_header(console)
 
-    from openff.bespokefit.executor.services import settings
+    from openff.bespokefit.executor.services import current_settings
     from openff.bespokefit.executor.services.coordinator.models import (
         CoordinatorGETPageResponse,
     )
     from openff.bespokefit.executor.utilities import handle_common_errors
+
+    settings = current_settings()
 
     base_href = (
         f"http://127.0.0.1:"

--- a/openff/bespokefit/executor/services/__init__.py
+++ b/openff/bespokefit/executor/services/__init__.py
@@ -1,5 +1,8 @@
 from openff.bespokefit.executor.services._settings import Settings
 
-settings = Settings()
 
-__all__ = ["settings", "Settings"]
+def current_settings() -> Settings:
+    return Settings()
+
+
+__all__ = ["current_settings", "Settings"]

--- a/openff/bespokefit/executor/services/coordinator/app.py
+++ b/openff/bespokefit/executor/services/coordinator/app.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, HTTPException
 from fastapi.responses import Response
 from openff.toolkit.topology import Molecule
 
-from openff.bespokefit.executor.services import settings
+from openff.bespokefit.executor.services import current_settings
 from openff.bespokefit.executor.services.coordinator import worker
 from openff.bespokefit.executor.services.coordinator.models import (
     CoordinatorGETPageResponse,
@@ -32,8 +32,10 @@ router = APIRouter()
 _logger = logging.getLogger(__name__)
 _worker_task: Optional[asyncio.Future] = None
 
+__settings = current_settings()
+
 __GET_TASK_IMAGE_ENDPOINT = (
-    "/" + settings.BEFLOW_COORDINATOR_PREFIX + "/{optimization_id}/image"
+    "/" + __settings.BEFLOW_COORDINATOR_PREFIX + "/{optimization_id}/image"
 )
 
 
@@ -56,7 +58,7 @@ def _get_task(
     return CoordinatorTask.parse_obj(pickle.loads(task_pickle))
 
 
-@router.get("/" + settings.BEFLOW_COORDINATOR_PREFIX)
+@router.get("/" + __settings.BEFLOW_COORDINATOR_PREFIX)
 def get_optimizations(skip: int = 0, limit: int = 1000) -> CoordinatorGETPageResponse:
     """Retrieves all bespoke optimizations that have been submitted to this server."""
 
@@ -75,8 +77,8 @@ def get_optimizations(skip: int = 0, limit: int = 1000) -> CoordinatorGETPageRes
     contents = [
         Link(
             self=(
-                f"{settings.BEFLOW_API_V1_STR}/"
-                f"{settings.BEFLOW_COORDINATOR_PREFIX}/"
+                f"{__settings.BEFLOW_API_V1_STR}/"
+                f"{__settings.BEFLOW_COORDINATOR_PREFIX}/"
                 f"{optimization_id}"
             ),
             id=optimization_id,
@@ -89,26 +91,26 @@ def get_optimizations(skip: int = 0, limit: int = 1000) -> CoordinatorGETPageRes
 
     return CoordinatorGETPageResponse(
         self=(
-            f"{settings.BEFLOW_API_V1_STR}/"
-            f"{settings.BEFLOW_COORDINATOR_PREFIX}?skip={skip}&limit={limit}"
+            f"{__settings.BEFLOW_API_V1_STR}/"
+            f"{__settings.BEFLOW_COORDINATOR_PREFIX}?skip={skip}&limit={limit}"
         ),
         prev=None
         if prev_index >= skip
         else (
-            f"{settings.BEFLOW_API_V1_STR}/"
-            f"{settings.BEFLOW_COORDINATOR_PREFIX}?skip={prev_index}&limit={limit}"
+            f"{__settings.BEFLOW_API_V1_STR}/"
+            f"{__settings.BEFLOW_COORDINATOR_PREFIX}?skip={prev_index}&limit={limit}"
         ),
         next=None
         if (next_index <= skip or next_index == n_optimizations)
         else (
-            f"{settings.BEFLOW_API_V1_STR}/"
-            f"{settings.BEFLOW_COORDINATOR_PREFIX}?skip={next_index}&limit={limit}"
+            f"{__settings.BEFLOW_API_V1_STR}/"
+            f"{__settings.BEFLOW_COORDINATOR_PREFIX}?skip={next_index}&limit={limit}"
         ),
         contents=contents,
     )
 
 
-@router.get("/" + settings.BEFLOW_COORDINATOR_PREFIX + "/{optimization_id}")
+@router.get("/" + __settings.BEFLOW_COORDINATOR_PREFIX + "/{optimization_id}")
 def get_optimization(optimization_id: str) -> CoordinatorGETResponse:
     """Retrieves a bespoke optimization that has been submitted to this server
     using its unique id."""
@@ -118,7 +120,7 @@ def get_optimization(optimization_id: str) -> CoordinatorGETResponse:
     )
     response.links = {
         "image": (
-            settings.BEFLOW_API_V1_STR
+            __settings.BEFLOW_API_V1_STR
             + __GET_TASK_IMAGE_ENDPOINT.format(optimization_id=optimization_id)
         )
     }
@@ -126,7 +128,7 @@ def get_optimization(optimization_id: str) -> CoordinatorGETResponse:
     return response
 
 
-@router.post("/" + settings.BEFLOW_COORDINATOR_PREFIX)
+@router.post("/" + __settings.BEFLOW_COORDINATOR_PREFIX)
 def post_optimization(body: CoordinatorPOSTBody) -> CoordinatorPOSTResponse:
     """Submit a bespoke optimization to be performed by the server."""
 
@@ -159,8 +161,8 @@ def post_optimization(body: CoordinatorPOSTBody) -> CoordinatorPOSTResponse:
     return CoordinatorPOSTResponse(
         id=task_id,
         self=(
-            f"{settings.BEFLOW_API_V1_STR}/"
-            f"{settings.BEFLOW_COORDINATOR_PREFIX}/{task.id}"
+            f"{__settings.BEFLOW_API_V1_STR}/"
+            f"{__settings.BEFLOW_COORDINATOR_PREFIX}/{task.id}"
         ),
     )
 

--- a/openff/bespokefit/executor/services/coordinator/models.py
+++ b/openff/bespokefit/executor/services/coordinator/models.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Optional
 
 from pydantic import Field
 
-from openff.bespokefit.executor.services import settings
+from openff.bespokefit.executor.services import current_settings
 from openff.bespokefit.executor.services.coordinator.stages import StageType
 from openff.bespokefit.executor.services.models import Link, PaginatedCollection
 from openff.bespokefit.executor.utilities.typing import Status
@@ -48,6 +48,8 @@ class CoordinatorGETStageStatus(BaseModel):
         else:
             raise NotImplementedError()
 
+        settings = current_settings()
+
         base_endpoint = f"{settings.BEFLOW_API_V1_STR}/"
 
         endpoints = {
@@ -90,6 +92,8 @@ class CoordinatorGETResponse(Link):
 
     @classmethod
     def from_task(cls, task: "CoordinatorTask"):
+
+        settings = current_settings()
 
         stages = [
             *task.pending_stages,

--- a/openff/bespokefit/executor/services/coordinator/stages.py
+++ b/openff/bespokefit/executor/services/coordinator/stages.py
@@ -20,7 +20,7 @@ from qcelemental.util import serialize
 from qcengine.procedures.torsiondrive import TorsionDriveResult
 from typing_extensions import Literal
 
-from openff.bespokefit.executor.services import settings
+from openff.bespokefit.executor.services import current_settings
 from openff.bespokefit.executor.services.coordinator.utils import get_cached_parameters
 from openff.bespokefit.executor.services.fragmenter.models import (
     FragmenterGETResponse,
@@ -111,6 +111,8 @@ class FragmentationStage(_Stage):
 
     async def _enter(self, task: "CoordinatorTask"):
 
+        settings = current_settings()
+
         async with httpx.AsyncClient() as client:
 
             raw_response = await client.post(
@@ -142,6 +144,8 @@ class FragmentationStage(_Stage):
 
         if self.status == "errored":
             return
+
+        settings = current_settings()
 
         async with httpx.AsyncClient() as client:
 
@@ -209,6 +213,9 @@ class QCGenerationStage(_Stage):
         Returns:
             The list of generated smirks patterns including any cached values, and a list of fragments which require torsiondrives.
         """
+
+        settings = current_settings()
+
         cached_torsions = None
 
         if is_redis_available(
@@ -341,6 +348,8 @@ class QCGenerationStage(_Stage):
 
     async def _enter(self, task: "CoordinatorTask"):
 
+        settings = current_settings()
+
         fragment_stage = next(
             iter(
                 stage
@@ -422,6 +431,8 @@ class QCGenerationStage(_Stage):
         self.ids = {i: sorted(ids) for i, ids in qc_calc_ids.items()}
 
     async def _update(self):
+
+        settings = current_settings()
 
         if self.status == "errored":
             return
@@ -537,6 +548,8 @@ class OptimizationStage(_Stage):
 
     async def _enter(self, task: "CoordinatorTask"):
 
+        settings = current_settings()
+
         completed_stages = {stage.type: stage for stage in task.completed_stages}
 
         input_schema = task.input_schema.copy(deep=True)
@@ -580,6 +593,8 @@ class OptimizationStage(_Stage):
             self.id = response.id
 
     async def _update(self):
+
+        settings = current_settings()
 
         if self.status == "errored":
             return

--- a/openff/bespokefit/executor/services/coordinator/worker.py
+++ b/openff/bespokefit/executor/services/coordinator/worker.py
@@ -4,15 +4,17 @@ import pickle
 
 import redis
 
-from openff.bespokefit.executor.services import settings
+from openff.bespokefit.executor.services import current_settings
 from openff.bespokefit.executor.services.coordinator.models import CoordinatorTask
 
 _logger = logging.getLogger(__name__)
 
+__settings = current_settings()
+
 redis_connection = redis.Redis(
-    host=settings.BEFLOW_REDIS_ADDRESS,
-    port=settings.BEFLOW_REDIS_PORT,
-    db=settings.BEFLOW_REDIS_DB,
+    host=__settings.BEFLOW_REDIS_ADDRESS,
+    port=__settings.BEFLOW_REDIS_PORT,
+    db=__settings.BEFLOW_REDIS_DB,
 )
 
 

--- a/openff/bespokefit/executor/services/fragmenter/app.py
+++ b/openff/bespokefit/executor/services/fragmenter/app.py
@@ -5,7 +5,7 @@ from fastapi.responses import Response
 from openff.fragmenter.depiction import _oe_render_fragment
 from openff.fragmenter.fragment import FragmentationResult
 
-from openff.bespokefit.executor.services import settings
+from openff.bespokefit.executor.services import current_settings
 from openff.bespokefit.executor.services.fragmenter import worker
 from openff.bespokefit.executor.services.fragmenter.cache import (
     cached_fragmentation_task,
@@ -20,10 +20,12 @@ from openff.bespokefit.executor.utilities.depiction import IMAGE_UNAVAILABLE_SVG
 
 router = APIRouter()
 
-__GET_ENDPOINT = "/" + settings.BEFLOW_FRAGMENTER_PREFIX + "/{fragmentation_id}"
+__settings = current_settings()
+
+__GET_ENDPOINT = "/" + __settings.BEFLOW_FRAGMENTER_PREFIX + "/{fragmentation_id}"
 __GET_FRAGMENT_IMAGE_ENDPOINT = (
     "/"
-    + settings.BEFLOW_FRAGMENTER_PREFIX
+    + __settings.BEFLOW_FRAGMENTER_PREFIX
     + "/{fragmentation_id}/fragment/{fragment_id}/image"
 )
 
@@ -36,14 +38,14 @@ def get_fragment(fragmentation_id: str) -> FragmenterGETResponse:
 
     return FragmenterGETResponse(
         id=fragmentation_id,
-        self=settings.BEFLOW_API_V1_STR
+        self=__settings.BEFLOW_API_V1_STR
         + __GET_ENDPOINT.format(fragmentation_id=fragmentation_id),
         status=task_info["status"],
         result=task_result,
         error=json.dumps(task_info["error"]),
         _links={
             f"fragment-{i}-image": (
-                settings.BEFLOW_API_V1_STR
+                __settings.BEFLOW_API_V1_STR
                 + __GET_FRAGMENT_IMAGE_ENDPOINT.format(
                     fragmentation_id=fragmentation_id, fragment_id=i
                 )
@@ -55,7 +57,7 @@ def get_fragment(fragmentation_id: str) -> FragmenterGETResponse:
     )
 
 
-@router.post("/" + settings.BEFLOW_FRAGMENTER_PREFIX)
+@router.post("/" + __settings.BEFLOW_FRAGMENTER_PREFIX)
 def post_fragment(body: FragmenterPOSTBody) -> FragmenterPOSTResponse:
     # We use celery delay method in order to enqueue the task with the given
     # parameters
@@ -65,7 +67,7 @@ def post_fragment(body: FragmenterPOSTBody) -> FragmenterPOSTResponse:
     )
     return FragmenterPOSTResponse(
         id=task_id,
-        self=settings.BEFLOW_API_V1_STR
+        self=__settings.BEFLOW_API_V1_STR
         + __GET_ENDPOINT.format(fragmentation_id=task_id),
     )
 

--- a/openff/bespokefit/executor/services/fragmenter/worker.py
+++ b/openff/bespokefit/executor/services/fragmenter/worker.py
@@ -10,13 +10,15 @@ from openff.fragmenter.fragment import (
 from pydantic import parse_raw_as
 
 import openff.bespokefit
-from openff.bespokefit.executor.services import settings
+from openff.bespokefit.executor.services import current_settings
 from openff.bespokefit.executor.utilities.celery import configure_celery_app
 
+__settings = current_settings()
+
 redis_connection = redis.Redis(
-    host=settings.BEFLOW_REDIS_ADDRESS,
-    port=settings.BEFLOW_REDIS_PORT,
-    db=settings.BEFLOW_REDIS_DB,
+    host=__settings.BEFLOW_REDIS_ADDRESS,
+    port=__settings.BEFLOW_REDIS_PORT,
+    db=__settings.BEFLOW_REDIS_DB,
 )
 celery_app = configure_celery_app("fragmenter", redis_connection)
 

--- a/openff/bespokefit/executor/services/optimizer/app.py
+++ b/openff/bespokefit/executor/services/optimizer/app.py
@@ -3,7 +3,7 @@ import json
 from fastapi import APIRouter
 from qcelemental.util import serialize
 
-from openff.bespokefit.executor.services import settings
+from openff.bespokefit.executor.services import current_settings
 from openff.bespokefit.executor.services.optimizer import worker
 from openff.bespokefit.executor.services.optimizer.models import (
     OptimizerGETResponse,
@@ -14,7 +14,9 @@ from openff.bespokefit.executor.utilities.celery import get_task_information
 
 router = APIRouter()
 
-__GET_ENDPOINT = "/" + settings.BEFLOW_OPTIMIZER_PREFIX + "/{optimization_id}"
+__settings = current_settings()
+
+__GET_ENDPOINT = "/" + __settings.BEFLOW_OPTIMIZER_PREFIX + "/{optimization_id}"
 
 
 @router.get(__GET_ENDPOINT)
@@ -25,7 +27,7 @@ def get_optimization(optimization_id: str) -> OptimizerGETResponse:
     # noinspection PyTypeChecker
     return {
         "id": optimization_id,
-        "self": settings.BEFLOW_API_V1_STR
+        "self": __settings.BEFLOW_API_V1_STR
         + __GET_ENDPOINT.format(optimization_id=optimization_id),
         "status": task_info["status"],
         "result": task_info["result"],
@@ -33,7 +35,7 @@ def get_optimization(optimization_id: str) -> OptimizerGETResponse:
     }
 
 
-@router.post("/" + settings.BEFLOW_OPTIMIZER_PREFIX)
+@router.post("/" + __settings.BEFLOW_OPTIMIZER_PREFIX)
 def post_optimization(body: OptimizerPOSTBody) -> OptimizerPOSTResponse:
     # We use celery delay method in order to enqueue the task with the given
     # parameters
@@ -43,6 +45,6 @@ def post_optimization(body: OptimizerPOSTBody) -> OptimizerPOSTResponse:
     )
     return OptimizerPOSTResponse(
         id=task.id,
-        self=settings.BEFLOW_API_V1_STR
+        self=__settings.BEFLOW_API_V1_STR
         + __GET_ENDPOINT.format(optimization_id=task.id),
     )

--- a/openff/bespokefit/executor/services/qcgenerator/worker.py
+++ b/openff/bespokefit/executor/services/qcgenerator/worker.py
@@ -21,14 +21,16 @@ from qcelemental.models.procedures import (
 from qcelemental.util import serialize
 from qcengine.config import get_global
 
-from openff.bespokefit.executor.services import settings
+from openff.bespokefit.executor.services import current_settings
 from openff.bespokefit.executor.utilities.celery import configure_celery_app
 from openff.bespokefit.schema.tasks import OptimizationTask, Torsion1DTask
 
+__settings = current_settings()
+
 redis_connection = redis.Redis(
-    host=settings.BEFLOW_REDIS_ADDRESS,
-    port=settings.BEFLOW_REDIS_PORT,
-    db=settings.BEFLOW_REDIS_DB,
+    host=__settings.BEFLOW_REDIS_ADDRESS,
+    port=__settings.BEFLOW_REDIS_PORT,
+    db=__settings.BEFLOW_REDIS_DB,
 )
 celery_app = configure_celery_app("qcgenerator", redis_connection)
 
@@ -37,7 +39,7 @@ _task_logger: logging.Logger = get_task_logger(__name__)
 
 def _task_config() -> Dict[str, Any]:
 
-    worker_settings = settings.qc_compute_settings
+    worker_settings = __settings.qc_compute_settings
 
     n_cores = (
         get_global("ncores") if not worker_settings.n_cores else worker_settings.n_cores

--- a/openff/bespokefit/tests/cli/executor/test_list.py
+++ b/openff/bespokefit/tests/cli/executor/test_list.py
@@ -3,7 +3,7 @@ import requests_mock
 import rich
 
 from openff.bespokefit.cli.executor.list import _get_columns, list_cli
-from openff.bespokefit.executor.services import settings
+from openff.bespokefit.executor.services import current_settings
 from openff.bespokefit.executor.services.coordinator.models import (
     CoordinatorGETPageResponse,
     CoordinatorGETResponse,
@@ -12,6 +12,8 @@ from openff.bespokefit.executor.services.models import Link
 
 
 def test_get_columns():
+
+    settings = current_settings()
 
     with requests_mock.Mocker() as m:
 
@@ -42,6 +44,8 @@ def test_get_columns():
     [(0, "No optimizations were found"), (3, "The following optimizations were found")],
 )
 def test_list_cli(n_results, expected_message, runner):
+
+    settings = current_settings()
 
     with requests_mock.Mocker() as m:
 

--- a/openff/bespokefit/tests/cli/executor/test_retrieve.py
+++ b/openff/bespokefit/tests/cli/executor/test_retrieve.py
@@ -5,7 +5,7 @@ import pytest
 import requests_mock
 
 from openff.bespokefit.cli.executor.retrieve import retrieve_cli
-from openff.bespokefit.executor.services import settings
+from openff.bespokefit.executor.services import current_settings
 from openff.bespokefit.executor.services.coordinator.models import (
     CoordinatorGETResponse,
     CoordinatorGETStageStatus,
@@ -14,6 +14,7 @@ from openff.bespokefit.executor.services.coordinator.models import (
 
 @contextmanager
 def _mock_coordinator_get(status, results=None):
+    settings = current_settings()
 
     with requests_mock.Mocker() as m:
 

--- a/openff/bespokefit/tests/cli/executor/test_run.py
+++ b/openff/bespokefit/tests/cli/executor/test_run.py
@@ -4,7 +4,7 @@ import requests_mock
 from openff.toolkit.topology import Molecule
 
 from openff.bespokefit.cli.executor.run import run_cli
-from openff.bespokefit.executor.services import settings
+from openff.bespokefit.executor.services import current_settings
 from openff.bespokefit.executor.services.coordinator.models import (
     CoordinatorGETResponse,
     CoordinatorGETStageStatus,
@@ -17,6 +17,8 @@ def test_run(runner, tmpdir):
 
     input_file_path = os.path.join(tmpdir, "mol.sdf")
     Molecule.from_smiles("CC").to_file(input_file_path, "SDF")
+
+    settings = current_settings()
 
     with requests_mock.Mocker() as m:
 

--- a/openff/bespokefit/tests/cli/executor/test_submit.py
+++ b/openff/bespokefit/tests/cli/executor/test_submit.py
@@ -16,7 +16,7 @@ from openff.bespokefit.cli.executor.submit import (
     _to_input_schema,
     submit_cli,
 )
-from openff.bespokefit.executor.services import settings
+from openff.bespokefit.executor.services import current_settings
 from openff.bespokefit.executor.services.coordinator.models import (
     CoordinatorPOSTResponse,
 )
@@ -220,6 +220,8 @@ def test_submit_invalid_schema(tmpdir):
 def test_submit(tmpdir, file, smiles):
     """Make sure to schema failures are cleanly handled."""
 
+    settings = current_settings()
+
     with requests_mock.Mocker() as m:
 
         mock_href = (
@@ -244,6 +246,8 @@ def test_submit(tmpdir, file, smiles):
 
 def test_submit_cli(runner, tmpdir):
     """Make sure to schema failures are cleanly handled."""
+
+    settings = current_settings()
 
     input_file_path = os.path.join(tmpdir, "mol.sdf")
     Molecule.from_smiles("CC").to_file(input_file_path, "SDF")

--- a/openff/bespokefit/tests/cli/executor/test_watch.py
+++ b/openff/bespokefit/tests/cli/executor/test_watch.py
@@ -1,7 +1,7 @@
 import requests_mock
 
 from openff.bespokefit.cli.executor.watch import watch_cli
-from openff.bespokefit.executor.services import settings
+from openff.bespokefit.executor.services import current_settings
 from openff.bespokefit.executor.services.coordinator.models import (
     CoordinatorGETResponse,
     CoordinatorGETStageStatus,
@@ -9,6 +9,8 @@ from openff.bespokefit.executor.services.coordinator.models import (
 
 
 def test_watch(runner):
+
+    settings = current_settings()
 
     with requests_mock.Mocker() as m:
 

--- a/openff/bespokefit/tests/executor/__init__.py
+++ b/openff/bespokefit/tests/executor/__init__.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 
 import redis
 
-from openff.bespokefit.executor.services import settings
+from openff.bespokefit.executor.services import Settings
 
 try:
     from pytest_cov.embed import cleanup_on_sigterm
@@ -15,18 +15,10 @@ else:
 @contextmanager
 def patch_settings(redis_connection: redis.Redis):
 
-    old_settings = settings.copy(deep=True)
+    with Settings(
+        BEFLOW_REDIS_ADDRESS=redis_connection.connection_pool.connection_kwargs["host"],
+        BEFLOW_REDIS_PORT=redis_connection.connection_pool.connection_kwargs["port"],
+        BEFLOW_REDIS_DB=redis_connection.connection_pool.connection_kwargs["db"],
+    ).apply_env():
 
-    settings.BEFLOW_REDIS_ADDRESS = redis_connection.connection_pool.connection_kwargs[
-        "host"
-    ]
-    settings.BEFLOW_REDIS_PORT = redis_connection.connection_pool.connection_kwargs[
-        "port"
-    ]
-    settings.BEFLOW_REDIS_DB = redis_connection.connection_pool.connection_kwargs["db"]
-
-    yield
-
-    settings.BEFLOW_REDIS_ADDRESS = old_settings.BEFLOW_REDIS_ADDRESS
-    settings.BEFLOW_REDIS_PORT = old_settings.BEFLOW_REDIS_PORT
-    settings.BEFLOW_REDIS_DB = old_settings.BEFLOW_REDIS_DB
+        yield

--- a/openff/bespokefit/tests/executor/services/test_gateway.py
+++ b/openff/bespokefit/tests/executor/services/test_gateway.py
@@ -3,7 +3,7 @@ from multiprocessing import Process
 
 import pytest
 
-from openff.bespokefit.executor.services import settings
+from openff.bespokefit.executor.services import Settings
 from openff.bespokefit.executor.services.gateway import app, launch, wait_for_gateway
 
 
@@ -36,7 +36,7 @@ def test_launch(directory):
 
 def test_wait_for_gateway_timeout(monkeypatch):
 
-    monkeypatch.setattr(settings, "BEFLOW_GATEWAY_PORT", 111)
+    with Settings(BEFLOW_GATEWAY_PORT=111).apply_env():
 
-    with pytest.raises(RuntimeError, match="The gateway could not be reached"):
-        wait_for_gateway(n_retries=1)
+        with pytest.raises(RuntimeError, match="The gateway could not be reached"):
+            wait_for_gateway(n_retries=1)

--- a/openff/bespokefit/tests/executor/test_executor.py
+++ b/openff/bespokefit/tests/executor/test_executor.py
@@ -12,7 +12,7 @@ from openff.bespokefit.executor import (
     BespokeExecutorStageOutput,
     wait_until_complete,
 )
-from openff.bespokefit.executor.services import settings
+from openff.bespokefit.executor.services import current_settings
 from openff.bespokefit.executor.services.coordinator.models import (
     CoordinatorGETResponse,
     CoordinatorGETStageStatus,
@@ -22,6 +22,8 @@ from openff.bespokefit.executor.services.coordinator.models import (
 
 @contextmanager
 def mock_get_response(stage_status="running") -> CoordinatorGETResponse:
+
+    settings = current_settings()
 
     mock_id = "mock-id"
 
@@ -287,6 +289,7 @@ class TestBespokeExecutor:
             executor._stop()
 
     def test_submit(self, bespoke_optimization_schema):
+        settings = current_settings()
 
         expected = CoordinatorPOSTResponse(id="mock-id", self="")
 
@@ -358,6 +361,8 @@ def test_query_coordinator():
         context.status_code = 200
         return mock_response.json(by_alias=True)
 
+    settings = current_settings()
+
     mock_href = (
         f"http://127.0.0.1:"
         f"{settings.BEFLOW_GATEWAY_PORT}"
@@ -402,6 +407,8 @@ def test_wait_for_stage(status):
         n_requests += 1
 
         return response_json
+
+    settings = current_settings()
 
     mock_href = (
         f"http://127.0.0.1:"


### PR DESCRIPTION
## Description

This PR replaces the 'dangerous' `settings` field exposed by the bespoke executor with a more reliable function that returns the most up-to-date values.

The object returned by `current_settings()` should not be modified as the changes will have no effect. Instead the `apply_env` context manager should be used e.g.

```python
with Settings(
    BEFLOW_FRAGMENTER_WORKER_N_CORES=...,
    BEFLOW_FRAGMENTER_WORKER_MAX_MEM=...
).apply_env():

    settings = current_settings()
```

Possibly fixes #130 

## Status
- [x] Ready to go