### PR TITLE
Add CLI override for default bespoke QC spec

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -72,6 +72,10 @@ it with bespoke parameters generated according to the [default built-in workflow
 :::{note}
 Other available workflow can be viewed by running `openff-bespoke executor run --help`, or alternatively, the path to a 
 [saved workflow factory](quick_start_config_factory) can also be provided using the `--workflow-file` flag.
+
+Alternatively, certain options defined by the workflow can be overridden from the CLI. For example, the default
+specification to use for any new QC calculations can be specified using the `--default-qc-spec` flag, e.g.
+`--default-qc-spec xtb gfn2xtb none`. See the `--help` for other available overrides.
 :::
 
 By default, BespokeFit will use create a single worker for each step in the fitting workflow (i.e. one for fragmenting 

--- a/openff/bespokefit/cli/executor/run.py
+++ b/openff/bespokefit/cli/executor/run.py
@@ -18,6 +18,7 @@ def _run_cli(
     output_force_field_path: Optional[str],
     force_field_path: Optional[str],
     target_torsion_smirks: Tuple[str],
+    default_qc_spec: Optional[Tuple[str, str, str]],
     workflow_name: Optional[str],
     workflow_file_name: Optional[str],
     directory: Optional[str],
@@ -74,6 +75,7 @@ def _run_cli(
                 molecule_smiles=molecule_smiles,
                 force_field_path=force_field_path,
                 target_torsion_smirks=target_torsion_smirks,
+                default_qc_spec=default_qc_spec,
                 workflow_name=workflow_name,
                 workflow_file_name=workflow_file_name,
             )


### PR DESCRIPTION
## Description

This PR adds a new `--default-qc-spec` CLI flag that easily allows users to override the default QC spec set by a workflow / workflow file without needing to create a new one in python.

This should make it easier for less-python centric users to experiment with different QC methods.

## Status
- [X] Ready to go