### PR TITLE
Add option to `list` CLI to filter by status

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -147,6 +147,12 @@ A full list of submissions currently being processes can be printed with the `li
 openff-bespoke executor list
 ```
 
+or if you would only like to inspect those that have failed for example:
+
+```shell
+openff-bespoke executor list --status errored
+```
+
 Once finished, the final force field can be retrieved using the `retrieve` command:
 
 ```shell

--- a/openff/bespokefit/cli/executor/list.py
+++ b/openff/bespokefit/cli/executor/list.py
@@ -61,6 +61,10 @@ def list_cli(status_filter: Status):
 
     settings = current_settings()
 
+    # In the coordinator we keep both successful and errored tasks in the same 'complete'
+    # queue to avoid having to maintain and query to separate lists in redis, so here we
+    # need to condense these two states into one and then apply a second filter when
+    # iterating over the returned ids.
     status_url = (
         None
         if status_filter is None

--- a/openff/bespokefit/cli/executor/list.py
+++ b/openff/bespokefit/cli/executor/list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Tuple
+from typing import Tuple, get_args
 
 import click
 import click.exceptions
@@ -8,9 +8,14 @@ from rich import pretty
 from rich.table import Table
 
 from openff.bespokefit.cli.utilities import print_header
+from openff.bespokefit.schema import Status
 
-if TYPE_CHECKING:
-    from openff.bespokefit.executor.utilities.typing import Status
+_STATUS_STRINGS = {
+    "waiting": "[grey]waiting[/grey]",
+    "running": "[yellow]running[/yellow]",
+    "success": "[green]success[/green]",
+    "errored": "[red]errored[/red]",
+}
 
 
 def _get_columns(console: "rich.Console", optimization_id: str) -> Tuple[str, "Status"]:
@@ -32,8 +37,15 @@ def _get_columns(console: "rich.Console", optimization_id: str) -> Tuple[str, "S
     return smiles, output.status
 
 
+@click.option(
+    "--status",
+    "status_filter",
+    type=click.Choice(get_args(Status)),
+    help="The (optional) status to filter by",
+    required=False,
+)
 @click.command("list")
-def list_cli():
+def list_cli(status_filter: Status):
     """List the ids of any bespoke optimizations."""
 
     pretty.install()
@@ -49,11 +61,19 @@ def list_cli():
 
     settings = current_settings()
 
+    status_url = (
+        None
+        if status_filter is None
+        else status_filter.replace("success", "complete").replace("errored", "complete")
+    )
+    status_url = "" if status_url is None else f"?status={status_url}"
+
     base_href = (
         f"http://127.0.0.1:"
         f"{settings.BEFLOW_GATEWAY_PORT}"
         f"{settings.BEFLOW_API_V1_STR}/"
         f"{settings.BEFLOW_COORDINATOR_PREFIX}"
+        f"{status_url}"
     )
 
     with handle_common_errors(console) as error_state:
@@ -65,9 +85,26 @@ def list_cli():
         raise click.exceptions.Exit(code=2)
 
     response = CoordinatorGETPageResponse.parse_raw(request.content)
+    records = []
 
-    if len(response.contents) == 0:
-        console.print("No optimizations were found.")
+    for item in response.contents:
+
+        smiles, status = _get_columns(console, item.id)
+
+        if status_filter is not None and status != status_filter:
+            continue
+
+        records.append((item.id, smiles, status))
+
+    if len(records) == 0:
+
+        status_message = (
+            "."
+            if status_filter is None
+            else f" with status {_STATUS_STRINGS[status_filter]}"
+        )
+        console.print(f"No optimizations were found{status_message}")
+
         return
 
     table = Table()
@@ -76,18 +113,16 @@ def list_cli():
     table.add_column("SMILES", overflow="fold")
     table.add_column("STATUS", no_wrap=True)
 
-    for item in response.contents:
+    for record_id, smiles, status in records:
 
-        smiles, status = _get_columns(console, item.id)
+        smiles, status = _get_columns(console, record_id)
 
-        status_string = {
-            "waiting": "[grey]waiting[/grey]",
-            "running": "[yellow]running[/yellow]",
-            "success": "[green]success[/green]",
-            "errored": "[red]errored[/red]",
-        }[status]
+        if status_filter is not None and status != status_filter:
+            continue
 
-        table.add_row(item.id, smiles, status_string)
+        status_string = _STATUS_STRINGS[status]
+
+        table.add_row(record_id, smiles, status_string)
 
     console.print("The following optimizations were found:")
     console.print(table)


### PR DESCRIPTION
## Description

This PR allows users to more easily filter which optimisations currently have what status when using the `list` executor command.

## Status
- [X] Ready to go