### PR TITLE
Add single point jobs to the end of torsiondrives

### DIFF
--- a/openff/bespokefit/executor/services/qcgenerator/worker.py
+++ b/openff/bespokefit/executor/services/qcgenerator/worker.py
@@ -1,12 +1,17 @@
+import datetime
+import hashlib
+import json
 import logging
-from typing import Any, Dict, List
+import uuid
+from multiprocessing import Pool
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import psutil
 import qcelemental
 import qcengine
 from celery.utils.log import get_task_logger
 from openff.toolkit.topology import Atom, Molecule
-from qcelemental.models import AtomicResult
+from qcelemental.models import AtomicInput, AtomicResult
 from qcelemental.models.common_models import DriverEnum
 from qcelemental.models.procedures import (
     OptimizationInput,
@@ -21,9 +26,17 @@ from qcelemental.util import serialize
 from qcengine.config import get_global
 
 from openff.bespokefit.executor.services import current_settings
+from openff.bespokefit.executor.services.qcgenerator.qcengine import _divide_config
 from openff.bespokefit.executor.utilities.celery import configure_celery_app
 from openff.bespokefit.executor.utilities.redis import connect_to_default_redis
-from openff.bespokefit.schema.tasks import OptimizationTask, Torsion1DTask
+from openff.bespokefit.schema.tasks import (
+    OptimizationTask,
+    QCGenerationTask,
+    Torsion1DTask,
+)
+
+if TYPE_CHECKING:
+    from redis import Redis
 
 celery_app = configure_celery_app(
     "qcgenerator", connect_to_default_redis(validate=False)
@@ -63,85 +76,229 @@ def _select_atom(atoms: List[Atom]) -> int:
     return candidate.molecule_atom_index
 
 
+def _load_cached_torsiondrive(
+    redis_connection: "Redis", task_hash: str
+) -> Optional[TorsionDriveResult]:
+    """
+    Try and load a cached torsiondrive from the redis connection
+    """
+    td_result = None
+    task_id = redis_connection.hget("qcgenerator:task-ids", task_hash)
+    if task_id is not None:
+        task_id = task_id.decode()
+        _task_logger.info(f"found cached torsiondrive with id:{task_id}")
+        task_meta = json.loads(redis_connection.get(f"celery-task-meta-{task_id}"))
+        td_result = TorsionDriveResult.parse_raw(task_meta["result"])
+
+    return td_result
+
+
 @celery_app.task(acks_late=True)
 def compute_torsion_drive(task_json: str) -> TorsionDriveResult:
     """Runs a torsion drive using QCEngine."""
 
     task = Torsion1DTask.parse_raw(task_json)
 
-    _task_logger.info(f"running 1D scan with {_task_config()}")
+    return_value = None
+    # look up the geometry optimisation
+    # here we drop the single point specification and search
+    sp_specification = (
+        task.sp_specification.copy(deep=True)
+        if task.sp_specification is not None
+        else None
+    )
+    task.sp_specification = None
+    redis_connection = connect_to_default_redis()
+    task_hash = hashlib.sha512(task.json().encode()).hexdigest()
 
-    molecule: Molecule = Molecule.from_smiles(task.smiles)
-    molecule.generate_conformers(n_conformers=task.n_conformers)
+    # only look up if there is a sp specification otherwise we get back this task
+    if sp_specification is not None:
+        return_value = _load_cached_torsiondrive(
+            redis_connection=redis_connection, task_hash=task_hash
+        )
 
-    map_to_atom_index = {
-        map_index: atom_index
-        for atom_index, map_index in molecule.properties["atom_map"].items()
-    }
+    if return_value is None:
+        # run the geometry optimisation if not in the cache
+        _task_logger.info(f"running 1D scan with {_task_config()}")
 
-    index_2 = map_to_atom_index[task.central_bond[0]]
-    index_3 = map_to_atom_index[task.central_bond[1]]
+        molecule: Molecule = Molecule.from_smiles(task.smiles)
+        molecule.generate_conformers(n_conformers=task.n_conformers)
 
-    index_1_atoms = [
-        atom
-        for atom in molecule.atoms[index_2].bonded_atoms
-        if atom.molecule_atom_index != index_3
-    ]
-    index_4_atoms = [
-        atom
-        for atom in molecule.atoms[index_3].bonded_atoms
-        if atom.molecule_atom_index != index_2
-    ]
+        map_to_atom_index = {
+            map_index: atom_index
+            for atom_index, map_index in molecule.properties["atom_map"].items()
+        }
 
-    del molecule.properties["atom_map"]
+        index_2 = map_to_atom_index[task.central_bond[0]]
+        index_3 = map_to_atom_index[task.central_bond[1]]
 
-    input_schema = TorsionDriveInput(
-        keywords=TDKeywords(
-            dihedrals=[
-                (
-                    _select_atom(index_1_atoms),
-                    index_2,
-                    index_3,
-                    _select_atom(index_4_atoms),
+        index_1_atoms = [
+            atom
+            for atom in molecule.atoms[index_2].bonded_atoms
+            if atom.molecule_atom_index != index_3
+        ]
+        index_4_atoms = [
+            atom
+            for atom in molecule.atoms[index_3].bonded_atoms
+            if atom.molecule_atom_index != index_2
+        ]
+
+        del molecule.properties["atom_map"]
+
+        input_schema = TorsionDriveInput(
+            keywords=TDKeywords(
+                dihedrals=[
+                    (
+                        _select_atom(index_1_atoms),
+                        index_2,
+                        index_3,
+                        _select_atom(index_4_atoms),
+                    )
+                ],
+                grid_spacing=[task.grid_spacing],
+                dihedral_ranges=[task.scan_range]
+                if task.scan_range is not None
+                else None,
+            ),
+            extras={
+                "canonical_isomeric_explicit_hydrogen_mapped_smiles": molecule.to_smiles(
+                    isomeric=True, explicit_hydrogens=True, mapped=True
                 )
-            ],
-            grid_spacing=[task.grid_spacing],
-            dihedral_ranges=[task.scan_range] if task.scan_range is not None else None,
-        ),
-        extras={
-            "canonical_isomeric_explicit_hydrogen_mapped_smiles": molecule.to_smiles(
-                isomeric=True, explicit_hydrogens=True, mapped=True
-            )
-        },
-        initial_molecule=[
-            molecule.to_qcschema(conformer=i) for i in range(molecule.n_conformers)
-        ],
-        input_specification=QCInputSpecification(
-            model=task.model,
-            driver=DriverEnum.gradient,
-        ),
-        optimization_spec=OptimizationSpecification(
-            procedure=task.optimization_spec.program,
-            keywords={
-                **task.optimization_spec.dict(exclude={"program", "constraints"}),
-                "program": task.program,
             },
-        ),
-    )
+            initial_molecule=[
+                molecule.to_qcschema(conformer=i) for i in range(molecule.n_conformers)
+            ],
+            input_specification=QCInputSpecification(
+                model=task.model,
+                driver=DriverEnum.gradient,
+            ),
+            optimization_spec=OptimizationSpecification(
+                procedure=task.optimization_spec.program,
+                keywords={
+                    **task.optimization_spec.dict(exclude={"program", "constraints"}),
+                    "program": task.program,
+                },
+            ),
+        )
 
-    return_value = qcengine.compute_procedure(
-        input_schema, "torsiondrive", raise_error=True, local_options=_task_config()
-    )
+        return_value = qcengine.compute_procedure(
+            input_schema,
+            "torsiondriveparallel",
+            raise_error=True,
+            local_options=_task_config(),
+        )
 
-    if isinstance(return_value, TorsionDriveResult):
+        if isinstance(return_value, TorsionDriveResult):
 
-        return_value = TorsionDriveResult(
-            **return_value.dict(exclude={"optimization_history", "stdout", "stderr"}),
-            optimization_history={},
+            return_value = TorsionDriveResult(
+                **return_value.dict(
+                    exclude={"optimization_history", "stdout", "stderr"}
+                ),
+                optimization_history={},
+            )
+        # cache the result of the geometry optimisation only if there is a single point spec
+        if sp_specification is not None:
+            task_id = str(uuid.uuid4())
+            redis_connection.hset("qcgenerator:types", task_id, task.type)
+            redis_connection.hset("qcgenerator:task-ids", task_hash, task_id)
+            # mock a result
+            task_meta = {
+                "status": "SUCCESS",
+                "result": return_value.json(),
+                "traceback": None,
+                "children": [],
+                "date_done": datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%f"),
+                "task_id": task_id,
+            }
+            redis_connection.set(f"celery-task-meta-{task_id}", json.dumps(task_meta))
+            _task_logger.info(f"caching torsiondrive result {task_id}")
+
+    # check if we need to do single points
+    if sp_specification is not None:
+        # no need for final cache as this is saved at the top level
+        return_value = _compute_torsiondrive_sp(
+            torsiondrive_result=return_value,
+            torsion_specification=sp_specification,
+            config=_task_config(),
         )
 
     # noinspection PyTypeChecker
     return return_value.json()
+
+
+def _compute_torsiondrive_sp(
+    torsiondrive_result: TorsionDriveResult,
+    torsion_specification: QCGenerationTask,
+    config: Dict[str, Any],
+) -> TorsionDriveResult:
+    """
+    Compute single points along the final optimised geometries from a torsion drive using the single point specification
+    on the task.
+    """
+    _task_logger.info(
+        f"performing single point evaluations using {torsion_specification}"
+    )
+    settings = current_settings()
+    program = torsion_specification.program
+    n_workers = settings.BEFLOW_QC_COMPUTE_WORKER_N_TASKS
+    config["retries"] = 4
+    if program == "psi4" and n_workers == "auto":
+        # we recommend 8 cores per worker for psi4 from our qcfractal jobs
+        n_workers = max([int(config["ncores"] / 8), 1])
+    elif n_workers == "auto":
+        # for low cost methods like ani or xtb they are fast enough to not need splitting
+        n_workers = 1
+
+    opt_config = _divide_config(
+        config=qcengine.config.TaskConfig.parse_obj(config), n_workers=n_workers
+    )
+
+    if n_workers > 1:
+        # split the tasks between a pool of workers
+        with Pool(processes=n_workers) as pool:
+            tasks = {
+                grid_point: pool.apply_async(
+                    func=_single_point,
+                    args=(molecule, torsion_specification, opt_config),
+                )
+                for grid_point, molecule in torsiondrive_result.final_molecules.items()
+            }
+            energies = {
+                grid_point: result.get() for grid_point, result in tasks.items()
+            }
+    else:
+        energies = {
+            grid_point: _single_point(
+                molecule=molecule,
+                specification=torsion_specification,
+                config=opt_config.dict(),
+            ).return_result
+            for grid_point, molecule in torsiondrive_result.final_molecules.items()
+        }
+    # format into a result
+    final_result = torsiondrive_result.copy(deep=True)
+    for grid_point, energy in energies.items():
+        final_result.final_energies[grid_point] = energy
+    return final_result
+
+
+def _single_point(
+    molecule: qcelemental.models.Molecule,
+    specification: QCGenerationTask,
+    config: Dict[str, Any],
+) -> AtomicResult:
+    """
+    Perform a single point calculation on the input qcelemental molecule.
+    """
+    sp_task = AtomicInput(
+        molecule=molecule, driver=DriverEnum.energy, model=specification.model
+    )
+    return qcengine.compute(
+        input_data=sp_task,
+        program=specification.program,
+        raise_error=True,
+        local_options=config,
+    )
 
 
 @celery_app.task

--- a/openff/bespokefit/schema/tasks.py
+++ b/openff/bespokefit/schema/tasks.py
@@ -14,7 +14,7 @@ from openff.bespokefit.utilities.pydantic import BaseModel
 
 class QCGenerationTask(BaseModel, abc.ABC):
 
-    type: Literal["base-task"]
+    type: Literal["base-task"] = "base-task"
 
     program: str = Field(..., description="The program to use to evaluate the model.")
     model: Model = Field(..., description=str(Model.__doc__))
@@ -76,6 +76,10 @@ class Torsion1DTaskSpec(QCGenerationTask):
     n_conformers: conint(gt=0) = Field(
         10,
         description="The number of initial conformers to seed the torsion drive with.",
+    )
+    sp_specification: Optional[QCGenerationTask] = Field(
+        None,
+        description="An extra optional specification used to compute the reference energy surface on the optimised geometries.",
     )
 
 

--- a/openff/bespokefit/workflows/bespoke.py
+++ b/openff/bespokefit/workflows/bespoke.py
@@ -49,6 +49,7 @@ from openff.bespokefit.schema.targets import (
 from openff.bespokefit.schema.tasks import (
     HessianTaskSpec,
     OptimizationTaskSpec,
+    QCGenerationTask,
     Torsion1DTaskSpec,
 )
 from openff.bespokefit.utilities import parallel
@@ -123,13 +124,16 @@ class BespokeWorkflowFactory(ClassBase):
         "we use the WBO fragmenter by the Open Force Field Consortium.",
     )
 
-    default_qc_specs: List[QCSpec] = Field(
-        default_factory=lambda: [QCSpec()],
-        description="The default specification (e.g. method, basis) to use when "
-        "performing any new QC calculations. If multiple specs are provided, each spec "
-        "will be considered in order until one is found that i) is available based on "
-        "the installed dependencies, and ii) is compatible with the molecule of "
-        "interest.",
+    default_qc_spec: QCSpec = Field(
+        default=QCSpec(),
+        description="The default specification (e.g. method, basis and program) to use when "
+        "performing any new QC calculations",
+    )
+
+    sp_qc_spec: Optional[QCSpec] = Field(
+        default=None,
+        description="The single point specification (e.g method, basis and "
+        "program that should be used to refine a torsion PES.",
     )
 
     @validator("initial_force_field")
@@ -416,16 +420,30 @@ class BespokeWorkflowFactory(ClassBase):
 
         return opt_schema
 
-    def _select_qc_spec(self, molecule: Molecule) -> QCSpec:
-        """Attempts to select a QC spec for a given molecule from the defaults list."""
+    def _validate_qc_spec(self, molecule: Molecule):
+        """Validates that the qc specifications would allow this molecule to be processed.
+        Here we only do very basic validation on the use of ANI models, xtb and psi4 cover all relevant elements.
+        """
+        from openff.qcsubmit.exceptions import MissingBasisCoverageError
 
-        if len(self.default_qc_specs) != 1:
+        methods = [
+            self.default_qc_spec.method.lower(),
+            self.sp_qc_spec.method.lower() if self.sp_qc_spec is not None else None,
+        ]
+        molecule_elements = {atom.element.symbol for atom in molecule.atoms}
+        ani_coverage = {
+            "ani1x": {"C", "H", "N", "O"},
+            "ani1ccx": {"C", "H", "N", "O"},
+            "ani2x": {"C", "H", "N", "O", "S", "F", "Cl"},
+        }
 
-            raise NotImplementedError(
-                "Currently only a single default QC spec must be specified."
-            )
-
-        return self.default_qc_specs[0]
+        for method in methods:
+            if method in ani_coverage:
+                difference = molecule_elements.difference(ani_coverage[method])
+                if difference:
+                    raise MissingBasisCoverageError(
+                        f"The following elements: {difference} are not covered by the method: {method} please use a different method."
+                    )
 
     def _build_optimization_schema(
         self,
@@ -434,6 +452,9 @@ class BespokeWorkflowFactory(ClassBase):
         local_qc_data: Optional[Dict[str, LocalQCData]] = None,
     ) -> BespokeOptimizationSchema:
         """For a given molecule schema build an optimization schema."""
+
+        # validate our ability to use the chosen specifications with this molecule
+        self._validate_qc_spec(molecule=molecule)
 
         force_field_editor = ForceFieldEditor(self.initial_force_field)
         ff_hash = hashlib.sha512(
@@ -450,7 +471,7 @@ class BespokeWorkflowFactory(ClassBase):
             "optimization": OptimizationTaskSpec,
             "hessian": HessianTaskSpec,
         }
-        default_qc_spec = self._select_qc_spec(molecule)
+        default_qc_spec = self.default_qc_spec
 
         local_qc_data = {} if local_qc_data is None else local_qc_data
 
@@ -471,6 +492,16 @@ class BespokeWorkflowFactory(ClassBase):
                     else default_qc_spec.basis,
                 ),
             )
+            if task_type == "torsion1d" and self.sp_qc_spec is not None:
+                target_specification.sp_specification = QCGenerationTask(
+                    program=self.sp_qc_spec.program.lower(),
+                    model=Model(
+                        method=self.sp_qc_spec.method.lower(),
+                        basis=self.sp_qc_spec.basis.lower()
+                        if self.sp_qc_spec.basis is not None
+                        else self.sp_qc_spec.basis,
+                    ),
+                )
             # only overwrite with general settings if not configured
             if target_schema.calculation_specification is None:
                 target_schema.calculation_specification = target_specification


### PR DESCRIPTION
## Description
This PR expands the torsiondrive task with an optional second QC specification which is used to perform single point energy evaluations on the optimised geometries to resolve the PES.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] add tests
  - [ ] fix the CLI arguments to reflect the new options

## Questions
- [ ] Question1

## Status
- [ ] Ready to go