### PR TITLE
Fix parallel torsiondrives

### DIFF
--- a/openff/bespokefit/executor/services/qcgenerator/worker.py
+++ b/openff/bespokefit/executor/services/qcgenerator/worker.py
@@ -130,7 +130,10 @@ def compute_torsion_drive(task_json: str) -> TorsionDriveResult:
     )
 
     return_value = qcengine.compute_procedure(
-        input_schema, "torsiondrive", raise_error=True, local_options=_task_config()
+        input_schema,
+        "torsiondriveparallel",
+        raise_error=True,
+        local_options=_task_config(),
     )
 
     if isinstance(return_value, TorsionDriveResult):

--- a/openff/bespokefit/executor/utilities/celery.py
+++ b/openff/bespokefit/executor/utilities/celery.py
@@ -55,7 +55,7 @@ def configure_celery_app(
     return celery_app
 
 
-def _spawn_worker(celery_app, concurrency: int = 1):
+def _spawn_worker(celery_app, concurrency: int = 1, pool: str = "prefork"):
 
     worker = celery_app.Worker(
         concurrency=concurrency,
@@ -63,12 +63,17 @@ def _spawn_worker(celery_app, concurrency: int = 1):
         logfile=f"celery-{celery_app.main}.log",
         quiet=True,
         hostname=celery_app.main,
+        pool=pool,
     )
     worker.start()
 
 
 def spawn_worker(
-    celery_app, concurrency: int = 1, asynchronous: bool = True
+    celery_app,
+    concurrency: int = 1,
+    asynchronous: bool = True,
+    daemon: bool = True,
+    pool: str = "prefork",
 ) -> Optional[multiprocessing.Process]:
 
     if concurrency < 1:
@@ -77,7 +82,7 @@ def spawn_worker(
     if asynchronous:  # pragma: no cover
 
         worker_process = multiprocessing.Process(
-            target=_spawn_worker, args=(celery_app, concurrency), daemon=True
+            target=_spawn_worker, args=(celery_app, concurrency, pool), daemon=daemon
         )
         worker_process.start()
 


### PR DESCRIPTION
## Description
This fixes a bug where the custom parallel torsiondrive code was not used. We also have to change the qc workers to be non daemon to allow them to use a process pool to run parallel optimisations and use the pool='solo' mode to launch the workers which means they run in the main task. See [here](https://www.distributedpython.com/2018/10/26/celery-execution-pool/) for more details. This does mean that the qc workers could be left as zombie processes and might not shut down correctly. In testing the workers also complain about missing heartbeats and the clocks going out of sync this should be fine as we don't use timers or countdowns. The workers also send a message to `sys.__stderr__` after they finish each task which floods the terminal. We can stop this by setting `sys.__stderr__=None` but this will also hide normal shutdown messages at the end of a run. 

Related to #166 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] How should we handle the stderr messages? 
- [ ] Is this the best way around the daemon lock?

## Status
- [ ] Ready to go