### PR TITLE
Fix SMIRNOFF angle prior literal validator

### DIFF
--- a/openff/bespokefit/schema/smirnoff.py
+++ b/openff/bespokefit/schema/smirnoff.py
@@ -188,7 +188,7 @@ class AngleHyperparameters(BaseSMIRKSHyperparameters):
 
     type: Literal["Angles"] = "Angles"
 
-    priors: Dict[Literal["k", "length"], PositiveFloat] = Field(
+    priors: Dict[Literal["k", "angle"], PositiveFloat] = Field(
         {"k": 10.0, "angle": 10.0}, description=""
     )
 


### PR DESCRIPTION
## Description

This PR fixes a copy paste typo on `AngleHyperparameters` whereby the prior currently expects 'length' rather than 'angle'

## Status
- [X] Ready to go