### PR TITLE
Use mamba in CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -34,6 +34,7 @@ jobs:
         if: ${{ matrix.openeye == true }}
         with:
           python-version: ${{ matrix.python-version }}
+          mamba-version: "*"
           environment-file: devtools/conda-envs/test-env.yaml
 
           channels: openeye,conda-forge,defaults

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -30,6 +30,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2.1.1
       with:
         python-version: ${{ matrix.python-version }}
+        mamba-version: "*"
         activate-environment: constructor
         environment-file: devtools/conda-envs/installer.yaml
         auto-activate-base: false


### PR DESCRIPTION
In #161 I noticed that same actions took a long time (~35 minutes) to prepare the conda env, probably because they don't use `mamba` by default. ([Or so I think.](https://github.com/conda-incubator/setup-miniconda#example-6-mamba)). These test environments are fairly complex but I'm still surprised they took so long.

I didn't find anything in closed issues about this - apologies if this has already been attempted.