### PR TITLE
Generalize QC task models to allow pre-optimization

### DIFF
--- a/openff/bespokefit/schema/tasks.py
+++ b/openff/bespokefit/schema/tasks.py
@@ -12,15 +12,60 @@ from typing_extensions import Literal
 from openff.bespokefit.utilities.pydantic import BaseModel
 
 
-class QCGenerationTask(BaseModel, abc.ABC):
+class SinglePointSpec(BaseModel):
+    """Defines the specification for performing a single point calculation."""
 
-    type: Literal["base-task"] = "base-task"
-
-    program: str = Field(..., description="The program to use to evaluate the model.")
-    model: Model = Field(..., description=str(Model.__doc__))
+    program: str = Field(description="The program to use to evaluate the model.")
+    model: Model = Field(description="The QC model to perform the single point using.")
 
 
-class HessianTaskSpec(QCGenerationTask):
+class OptimizationSpec(SinglePointSpec):
+    """Defines the specification for performing a conformer optimization."""
+
+    procedure: GeometricProcedure = Field(
+        GeometricProcedure(),
+        description="The procedure to follow when optimizing the conformer.",
+    )
+
+
+class BaseTaskSpec(BaseModel, abc.ABC):
+    """The base for tasks that will generate QC reference data that force field
+    parameters will be trained to.
+    """
+
+    type: Literal["base-task"]
+
+
+class HessianTaskSpec(BaseTaskSpec):
+    """
+
+    Examples:
+
+        Define the specification for a task that will optimize an initial set of *up to*
+        10 diverse conformers at the B3LYP-D3BJ/DZVP level of theory before finally
+        evaluting the hessian of the conformer with the lowest energy:
+
+        >>> HessianTaskSpec(
+        >>>     optimization_spec=OptimizationSpec(
+        >>>         model=Model(method="B3LYP-D3BJ", basis="DZVP"), program="psi4",
+        >>>     )
+        >>>     n_conformers=10,
+        >>> )
+
+        Create a specification for a task that will pre-optimize a set of conformers
+        using GFN2XTB, followed by a second optimization using B3LYP-D3BJ/DZVP, before
+        finally evaluting the hessian of the conformer with the lowest energy using
+        B3LYP-D3BJ/DZVP:
+
+        >>> HessianTaskSpec(
+        >>>     pre_optimization_spec=OptimizationSpec(
+        >>>         model=Model(method="GFN2XTB", basis=None), program="xtb",
+        >>>     ),
+        >>>     optimization_spec=OptimizationSpec(
+        >>>         model=Model(method="B3LYP-D3BJ", basis="DZVP"), program="psi4",
+        >>>     )
+        >>> )
+    """
 
     type: Literal["hessian"] = "hessian"
 
@@ -30,35 +75,86 @@ class HessianTaskSpec(QCGenerationTask):
         "hessian. Each conformer will be minimized and the one with the lowest energy "
         "will have its hessian computed.",
     )
-    optimization_spec: GeometricProcedure = Field(
-        GeometricProcedure(),
+
+    pre_optimization_spec: Optional[OptimizationSpec] = Field(
+        None,
+        description="The (optional) specification to follow when pre-optimizing each "
+        "conformer using a 'cheaper' level of theory. If no value is provided, a "
+        "pre-optimization will not be performed.",
+    )
+    optimization_spec: OptimizationSpec = Field(
         description="The specification for how to optimize each conformer before "
-        "computing the hessian.",
+        "computing the hessian of the lowest energy conformer.",
     )
 
 
 class HessianTask(HessianTaskSpec):
 
     smiles: str = Field(
-        ...,
         description="A fully indexed SMILES representation of the molecule to compute "
         "the hessian for.",
     )
 
 
 class OptimizationTaskSpec(HessianTaskSpec):
+    """
+    Examples:
+
+        Optimize multiple conformers of a molecule at the B3LYP-D3BJ/DZVP level of
+        theory
+
+        >>> OptimizationTaskSpec(
+        >>>     optimization_spec=OptimizationSpec(
+        >>>         model=Model(method="B3LYP-D3BJ", basis="DZVP"), program="psi4",
+        >>>     )
+        >>> )
+
+        Optimize multiple conformers of a molecule first using GFN2XTB, followed by
+        a second optimization using B3LYP-D3BJ/DZVP:
+
+        >>> OptimizationTaskSpec(
+        >>>     pre_optimization_spec=OptimizationSpec(
+        >>>         model=Model(method="GFN2XTB", basis=None), program="xtb",
+        >>>     ),
+        >>>     optimization_spec=OptimizationSpec(
+        >>>         model=Model(method="B3LYP-D3BJ", basis="DZVP"), program="psi4",
+        >>>     )
+        >>> )
+
+        Optimize multiple conformers of a molecule using GFN2XTB before evaluating
+        the final energy of each conformer using B3LYP-D3BJ/DZVP:
+
+        >>> OptimizationTaskSpec(
+        >>>     optimization_spec=OptimizationSpec(
+        >>>         model=Model(method="GFN2XTB", basis=None), program="xtb",
+        >>>     ),
+        >>>     evaluation_spec=SinglePointSpec(
+        >>>         model=Model(method="B3LYP-D3BJ", basis="DZVP"), program="psi4",
+        >>>     )
+        >>> )
+    """
+
     type: Literal["optimization"] = "optimization"
+
+    # Redefine base field to give a more specific description.
+    optimization_spec: OptimizationSpec = Field(
+        description="The specification for how to optimize each conformer.",
+    )
+    evaluation_spec: Optional[SinglePointSpec] = Field(
+        None,
+        description="The (optional) specification to follow when evaluating properties "
+        "of the final conformer such as the energy and gradient.",
+    )
 
 
 class OptimizationTask(OptimizationTaskSpec):
 
     smiles: str = Field(
-        ...,
         description="A fully indexed SMILES representation of the molecule to optimize.",
     )
 
 
-class Torsion1DTaskSpec(QCGenerationTask):
+class Torsion1DTaskSpec(BaseTaskSpec):
 
     type: Literal["torsion1d"] = "torsion1d"
 
@@ -67,26 +163,26 @@ class Torsion1DTaskSpec(QCGenerationTask):
         None, description="The range of grid angles to scan."
     )
 
-    optimization_spec: GeometricProcedure = Field(
-        GeometricProcedure(enforce=0.1, reset=True, qccnv=True, epsilon=0.0),
-        description="The specification for how to optimize the structure at each angle "
-        "in the scan.",
+    optimization_spec: OptimizationSpec = Field(
+        description="The specification for how to optimize each conformer at each "
+        "grid angle.",
+    )
+    evaluation_spec: Optional[SinglePointSpec] = Field(
+        None,
+        description="The (optional) specification to follow when evaluating evaluating "
+        "the energy at each grid angle. If no value is provided the level of theory "
+        "used to optimize the conformer at each grid angle will be used.",
     )
 
     n_conformers: conint(gt=0) = Field(
         10,
         description="The number of initial conformers to seed the torsion drive with.",
     )
-    sp_specification: Optional[QCGenerationTask] = Field(
-        None,
-        description="An extra optional specification used to compute the reference energy surface on the optimised geometries.",
-    )
 
 
 class Torsion1DTask(Torsion1DTaskSpec):
 
     smiles: str = Field(
-        ...,
         description="An indexed SMILES representation of the molecule to drive.",
     )
     central_bond: Tuple[int, int] = Field(
@@ -122,13 +218,13 @@ def task_from_result(result):
             smiles=off_mol.to_smiles(
                 isomeric=True, explicit_hydrogens=True, mapped=True
             ),
-            program=result.extras["program"],
-            model=result.input_specification.model,
             central_bond=(dihedral[1] + 1, dihedral[2] + 1),
             grid_spacing=result.keywords.grid_spacing[0],
             scan_range=result.keywords.dihedral_ranges,
-            optimization_spec=GeometricProcedure.from_opt_spec(
-                result.optimization_spec
+            optimization_spec=OptimizationSpec(
+                program=result.extras["program"],
+                model=result.input_specification.model,
+                procedure=GeometricProcedure.from_opt_spec(result.optimization_spec),
             ),
         )
     else:

--- a/openff/bespokefit/tests/cli/executor/test_submit.py
+++ b/openff/bespokefit/tests/cli/executor/test_submit.py
@@ -183,11 +183,13 @@ def test_to_input_schema_overwrite_spec(tmpdir):
         workflow_file_name=None,
     )
 
-    qc_spec = input_schema.stages[0].targets[0].calculation_specification
-    eval_spec = input_schema.stages[0].targets[0].reference_data.spec.sp_specification
-    assert qc_spec.program == "xtb"
-    assert qc_spec.model.method == "gfn2xtb"
-    assert qc_spec.model.basis is None
+    opt_spec = (
+        input_schema.stages[0].targets[0].calculation_specification.optimization_spec
+    )
+    eval_spec = input_schema.stages[0].targets[0].reference_data.spec.evaluation_spec
+    assert opt_spec.program == "xtb"
+    assert opt_spec.model.method == "gfn2xtb"
+    assert opt_spec.model.basis is None
     assert eval_spec.program == "torchani"
     assert eval_spec.model.basis is None
     assert eval_spec.model.method == "ani2x"

--- a/openff/bespokefit/tests/cli/test_cache.py
+++ b/openff/bespokefit/tests/cli/test_cache.py
@@ -131,7 +131,7 @@ def test_update_from_qcsubmit(redis_connection):
     # find the result in redis
     task_id = redis_connection.hget(
         name="qcgenerator:task-ids",
-        key="21212802afd507cae91fa9b8af76d7fa76174cc1ba4ab04b7c251aa5263598fbb79d9d85a7d0654257afe684312db399bbdbeb174366425a981ab20a31eb6938",
+        key="d68837c929ff61fb0d8eeda94648ad0da29146214452c5ad4e4c68b911099e05638a984e6101b3bf102ee639281893da85937457863d598b0931fe20253009c1",
     ).decode()
     assert redis_connection.hget("qcgenerator:types", task_id).decode() == "torsion1d"
 

--- a/openff/bespokefit/tests/executor/services/qcgenerator/test_app.py
+++ b/openff/bespokefit/tests/executor/services/qcgenerator/test_app.py
@@ -21,7 +21,12 @@ from openff.bespokefit.executor.services.qcgenerator.models import (
     QCGeneratorPOSTResponse,
 )
 from openff.bespokefit.executor.utilities.depiction import IMAGE_UNAVAILABLE_SVG
-from openff.bespokefit.schema.tasks import HessianTask, OptimizationTask, Torsion1DTask
+from openff.bespokefit.schema.tasks import (
+    HessianTask,
+    OptimizationSpec,
+    OptimizationTask,
+    Torsion1DTask,
+)
 from openff.bespokefit.tests.executor.mocking.celery import mock_celery_task
 
 
@@ -147,8 +152,10 @@ def test_get_qc_result(
             Torsion1DTask(
                 smiles="[CH2:1][CH2:2]",
                 central_bond=(1, 2),
-                program="rdkit",
-                model=Model(method="uff", basis=None),
+                optimization_spec=OptimizationSpec(
+                    program="rdkit",
+                    model=Model(method="uff", basis=None),
+                ),
             ),
             "compute_torsion_drive",
         ),
@@ -156,16 +163,20 @@ def test_get_qc_result(
             OptimizationTask(
                 smiles="[CH2:1][CH2:2]",
                 n_conformers=1,
-                program="rdkit",
-                model=Model(method="uff", basis=None),
+                optimization_spec=OptimizationSpec(
+                    program="rdkit",
+                    model=Model(method="uff", basis=None),
+                ),
             ),
             "compute_optimization",
         ),
         (
             HessianTask(
                 smiles="[CH2:1][CH2:2]",
-                program="rdkit",
-                model=Model(method="uff", basis=None),
+                optimization_spec=OptimizationSpec(
+                    program="rdkit",
+                    model=Model(method="uff", basis=None),
+                ),
             ),
             "compute_hessian",
         ),

--- a/openff/bespokefit/tests/executor/services/qcgenerator/test_app.py
+++ b/openff/bespokefit/tests/executor/services/qcgenerator/test_app.py
@@ -13,7 +13,6 @@ from qcelemental.models.procedures import (
 
 from openff.bespokefit.executor.services.qcgenerator import worker
 from openff.bespokefit.executor.services.qcgenerator.app import _retrieve_qc_result
-from openff.bespokefit.executor.services.qcgenerator.cache import _canonicalize_task
 from openff.bespokefit.executor.services.qcgenerator.models import (
     QCGeneratorGETPageResponse,
     QCGeneratorGETResponse,
@@ -22,7 +21,6 @@ from openff.bespokefit.executor.services.qcgenerator.models import (
 )
 from openff.bespokefit.executor.utilities.depiction import IMAGE_UNAVAILABLE_SVG
 from openff.bespokefit.schema.tasks import (
-    HessianTask,
     OptimizationSpec,
     OptimizationTask,
     Torsion1DTask,
@@ -170,16 +168,16 @@ def test_get_qc_result(
             ),
             "compute_optimization",
         ),
-        (
-            HessianTask(
-                smiles="[CH2:1][CH2:2]",
-                optimization_spec=OptimizationSpec(
-                    program="rdkit",
-                    model=Model(method="uff", basis=None),
-                ),
-            ),
-            "compute_hessian",
-        ),
+        # (
+        #     HessianTask(
+        #         smiles="[CH2:1][CH2:2]",
+        #         optimization_spec=OptimizationSpec(
+        #             program="rdkit",
+        #             model=Model(method="uff", basis=None),
+        #         ),
+        #     ),
+        #     "compute_hessian",
+        # ),
     ],
 )
 def test_post_qc_result(
@@ -193,7 +191,9 @@ def test_post_qc_result(
     )
     request.raise_for_status()
 
-    assert submitted_task_kwargs["task_json"] == _canonicalize_task(task).json()
+    assert (
+        submitted_task_kwargs["optimization_spec_json"] == task.optimization_spec.json()
+    )
     assert redis_connection.hget("qcgenerator:types", "1").decode() == task.type
 
     result = QCGeneratorPOSTResponse.parse_raw(request.text)

--- a/openff/bespokefit/tests/executor/services/qcgenerator/test_cache.py
+++ b/openff/bespokefit/tests/executor/services/qcgenerator/test_cache.py
@@ -6,7 +6,12 @@ from openff.bespokefit.executor.services.qcgenerator.cache import (
     _canonicalize_task,
     cached_compute_task,
 )
-from openff.bespokefit.schema.tasks import HessianTask, OptimizationTask, Torsion1DTask
+from openff.bespokefit.schema.tasks import (
+    HessianTask,
+    OptimizationSpec,
+    OptimizationTask,
+    Torsion1DTask,
+)
 from openff.bespokefit.tests.executor.mocking.celery import mock_celery_task
 
 
@@ -15,8 +20,10 @@ def test_canonicalize_torsion_task():
     original_task = Torsion1DTask(
         smiles="[H:1][C:2]([H:3])([H:4])[O:5][H:6]",
         central_bond=(2, 5),
-        program="rdkit",
-        model=Model(method="uff", basis=None),
+        optimization_spec=OptimizationSpec(
+            program="rdkit",
+            model=Model(method="uff", basis=None),
+        ),
     )
     canonical_task = _canonicalize_task(original_task)
 
@@ -31,8 +38,10 @@ def test_canonicalize_torsion_task():
             Torsion1DTask(
                 smiles="[CH2:1][CH2:2]",
                 central_bond=(1, 2),
-                program="rdkit",
-                model=Model(method="uff", basis=None),
+                optimization_spec=OptimizationSpec(
+                    program="rdkit",
+                    model=Model(method="uff", basis=None),
+                ),
             ),
             "compute_torsion_drive",
         ),
@@ -40,16 +49,20 @@ def test_canonicalize_torsion_task():
             OptimizationTask(
                 smiles="[CH2:1][CH2:2]",
                 n_conformers=1,
-                program="rdkit",
-                model=Model(method="uff", basis=None),
+                optimization_spec=OptimizationSpec(
+                    program="rdkit",
+                    model=Model(method="uff", basis=None),
+                ),
             ),
             "compute_optimization",
         ),
         (
             HessianTask(
                 smiles="[CH2:1][CH2:2]",
-                program="rdkit",
-                model=Model(method="uff", basis=None),
+                optimization_spec=OptimizationSpec(
+                    program="rdkit",
+                    model=Model(method="uff", basis=None),
+                ),
             ),
             "compute_hessian",
         ),

--- a/openff/bespokefit/tests/executor/services/qcgenerator/test_cache.py
+++ b/openff/bespokefit/tests/executor/services/qcgenerator/test_cache.py
@@ -7,7 +7,6 @@ from openff.bespokefit.executor.services.qcgenerator.cache import (
     cached_compute_task,
 )
 from openff.bespokefit.schema.tasks import (
-    HessianTask,
     OptimizationSpec,
     OptimizationTask,
     Torsion1DTask,
@@ -56,16 +55,16 @@ def test_canonicalize_torsion_task():
             ),
             "compute_optimization",
         ),
-        (
-            HessianTask(
-                smiles="[CH2:1][CH2:2]",
-                optimization_spec=OptimizationSpec(
-                    program="rdkit",
-                    model=Model(method="uff", basis=None),
-                ),
-            ),
-            "compute_hessian",
-        ),
+        # (
+        #     HessianTask(
+        #         smiles="[CH2:1][CH2:2]",
+        #         optimization_spec=OptimizationSpec(
+        #             program="rdkit",
+        #             model=Model(method="uff", basis=None),
+        #         ),
+        #     ),
+        #     "compute_hessian",
+        # ),
     ],
 )
 def test_cached_compute_task(

--- a/openff/bespokefit/tests/executor/services/qcgenerator/test_worker.py
+++ b/openff/bespokefit/tests/executor/services/qcgenerator/test_worker.py
@@ -5,28 +5,22 @@ from qcelemental.models.common_models import Model
 from qcelemental.models.procedures import OptimizationResult, TorsionDriveResult
 
 from openff.bespokefit.executor.services.qcgenerator import worker
-from openff.bespokefit.schema.tasks import (
-    OptimizationTask,
-    QCGenerationTask,
-    Torsion1DTask,
-)
+from openff.bespokefit.schema.tasks import OptimizationSpec
 
 
 def test_compute_torsion_drive():
 
-    task = Torsion1DTask(
+    result_json = worker.compute_torsion_drive(
         smiles="[F][CH2:1][CH2:2][F]",
         central_bond=(1, 2),
         grid_spacing=180,
         scan_range=(-180, 180),
-        program="rdkit",
-        model=Model(method="uff", basis=None),
-        sp_specification=QCGenerationTask(
-            program="rdkit", model=Model(method="mmff94", basis=None)
-        ),
+        optimization_spec_json=OptimizationSpec(
+            program="rdkit",
+            model=Model(method="uff", basis=None),
+        ).json(),
+        n_conformers=1,
     )
-
-    result_json = worker.compute_torsion_drive(task.json())
     assert isinstance(result_json, str)
 
     result_dict = json.loads(result_json)
@@ -50,14 +44,13 @@ def test_compute_torsion_drive():
 
 def test_compute_optimization():
 
-    task = OptimizationTask(
+    result_json = worker.compute_optimization(
         smiles="CCCCC",
+        optimization_spec_json=OptimizationSpec(
+            program="rdkit", model=Model(method="uff", basis=None)
+        ).json(),
         n_conformers=2,
-        program="rdkit",
-        model=Model(method="uff", basis=None),
     )
-
-    result_json = worker.compute_optimization(task.json())
     assert isinstance(result_json, str)
 
     result_dicts = json.loads(result_json)

--- a/openff/bespokefit/tests/schema/test_targets.py
+++ b/openff/bespokefit/tests/schema/test_targets.py
@@ -4,7 +4,11 @@ from qcelemental.models.common_models import Model
 
 from openff.bespokefit.schema.data import BespokeQCData
 from openff.bespokefit.schema.targets import TorsionProfileTargetSchema
-from openff.bespokefit.schema.tasks import HessianTaskSpec, Torsion1DTaskSpec
+from openff.bespokefit.schema.tasks import (
+    HessianTaskSpec,
+    OptimizationSpec,
+    Torsion1DTaskSpec,
+)
 
 
 def test_check_reference_data(qc_torsion_drive_results):
@@ -16,7 +20,9 @@ def test_check_reference_data(qc_torsion_drive_results):
     TorsionProfileTargetSchema(
         reference_data=BespokeQCData(
             spec=Torsion1DTaskSpec(
-                program="rdkit", model=Model(method="uff", basis=None)
+                optimization_spec=OptimizationSpec(
+                    program="rdkit", model=Model(method="uff", basis=None)
+                )
             )
         )
     )
@@ -27,7 +33,9 @@ def test_check_reference_data(qc_torsion_drive_results):
         TorsionProfileTargetSchema(
             reference_data=BespokeQCData(
                 spec=HessianTaskSpec(
-                    program="rdkit", model=Model(method="uff", basis=None)
+                    optimization_spec=OptimizationSpec(
+                        program="rdkit", model=Model(method="uff", basis=None)
+                    )
                 )
             )
         )

--- a/openff/bespokefit/workflows/bespoke.py
+++ b/openff/bespokefit/workflows/bespoke.py
@@ -48,8 +48,9 @@ from openff.bespokefit.schema.targets import (
 )
 from openff.bespokefit.schema.tasks import (
     HessianTaskSpec,
+    OptimizationSpec,
     OptimizationTaskSpec,
-    QCGenerationTask,
+    SinglePointSpec,
     Torsion1DTaskSpec,
 )
 from openff.bespokefit.utilities import parallel
@@ -485,17 +486,19 @@ class BespokeWorkflowFactory(ClassBase):
             # set the calculation specification for provenance and caching
             task_type = target_schema.bespoke_task_type()
             target_specification = task_type_to_spec[task_type](
-                program=default_qc_spec.program.lower(),
-                # lower to hit the cache more often
-                model=Model(
-                    method=default_qc_spec.method.lower(),
-                    basis=default_qc_spec.basis.lower()
-                    if default_qc_spec.basis is not None
-                    else default_qc_spec.basis,
-                ),
+                optimization_spec=OptimizationSpec(
+                    program=default_qc_spec.program.lower(),
+                    # lower to hit the cache more often
+                    model=Model(
+                        method=default_qc_spec.method.lower(),
+                        basis=default_qc_spec.basis.lower()
+                        if default_qc_spec.basis is not None
+                        else default_qc_spec.basis,
+                    ),
+                )
             )
             if task_type == "torsion1d" and self.evaluation_qc_spec is not None:
-                target_specification.sp_specification = QCGenerationTask(
+                target_specification.evaluation_spec = SinglePointSpec(
                     program=self.evaluation_qc_spec.program.lower(),
                     model=Model(
                         method=self.evaluation_qc_spec.method.lower(),


### PR DESCRIPTION
## Description

This PR proposes modifications to the QC reference task models to more readily allow for extra steps such as pre-optimization or re-evaluating properties post-process.

Initially I'd considered changing `optimization_spec` to allow a list of specs to be performed sequentially, but this seemed overly complicated and uneccessary.

## Status
- [X] Ready to go