### PR TITLE
Update Psi4 installation docs

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -58,7 +58,7 @@ create a working conda environment containing both.
 :::
 
 :::{note}
-Installing Psi4 into an existing environment sometimes fails because of subtle differences in
+On Linux, installing Psi4 into an existing environment sometimes fails because of subtle differences in
 compiled dependencies found in multiple channels. An alternative is to install everything when
 initially creating the environment using, with AmberTools:
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -47,7 +47,7 @@ conda install -c openeye openeye-toolkits
 recommended to be installed unless you intend to train against data generated using a surrogate such as ANI:
 
 ```shell
-conda install -c conda-forge -c defaults -c psi4 psi4
+conda install -c psi4 -c conda-forge -c defaults psi4
 ```
 
 [Psi4]: https://psicode.org/
@@ -55,6 +55,22 @@ conda install -c conda-forge -c defaults -c psi4 psi4
 :::{warning}
 There is an incompatibility between the AmberTools and Psi4 conda packages on Mac, and it is not possible to
 create a working conda environment containing both. 
+:::
+
+:::{note}
+Installing Psi4 into an existing environment sometimes fails because of subtle differences in
+compiled dependencies found in multiple channels. An alternative is to install everything when
+initially creating the environment using, with AmberTools:
+
+```shell
+conda create -n bespokefit-env -c psi4 -c conda-forge -c defaults python=3.9 openff-bespokefit psi4 ambertools "h5py<3.2"
+```
+
+or with OpenEye Toolkits:
+
+```shell
+conda create -n bespokefit-env -c psi4 -c conda-forge -c defaults -c openeye python=3.9 openff-bespokefit psi4 openeye-toolkits "h5py<3.2"
+```
 :::
 
 #### XTB


### PR DESCRIPTION
## Description
This PR improves the documentation around Psi4 installation by:
- [x] Updating the channel order (reproduction: https://github.com/openforcefield/openff-bespokefit/issues/183#issuecomment-1148932327)
- [x] Adding one-liners that we have found useful and generally recommended (as compared to installing Psi4 into an existing `conda-forge`-based environment)

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] Check if the `:::{note}` renders well

## Questions
- [ ] Question1

## Status
- [ ] Ready to go