### PR TITLE
Update quick start guide with MKL option with XTB

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -84,6 +84,17 @@ conda install -c conda-forge xtb-python
 
 [`xtb-python`]: https://github.com/grimme-lab/xtb-python
 
+`xtb-python` can _optionally_ be configured to use MKL as its compute backend by running
+
+```shell
+conda install -c conda-forge xtb-python "libblas=*=*mkl"
+```
+
+This likely provides better performance on Intel CPUs. Note that use of the MKL backend may be subject to additional
+license agreements with Intel. We currently understand it to be free for use by academics and companies generally, but
+it is not strictly open source.
+
+
 #### TorchANI
 
 [TorchANI] is a PyTorch implementation of the ANI neural network potentials from the Roitberg group that can be used as 


### PR DESCRIPTION
Resolves #180

I tried a few commands (only on macOS) and this one was the simplest. `xtb` can be added to the one-liner but as far as I can tell that doesn't change anything.

I stopped at seeing a solved environment from `mamba`, I didn't see if the installation completes or if the software actually runs this way. I'm also assuming the behavior is similar on Linux.

I found it hard to pin down a single license agreement; searching stuff like "MKL license" brought me to a mix of forum threads, licenses from several years ago, and documentation about "oneMKL" which may or may not be the same thing. I understand MKL to be ubiquitous and our users to be smart, so I don't think it's necessary to stuff a bunch of links into the minimal disclaimer I've added here.

Feel free to smith anything up or down as desired in review.