### PR TITLE
Deal with connectivity changes in QC generation

### DIFF
--- a/devtools/conda-envs/docs-env.yaml
+++ b/devtools/conda-envs/docs-env.yaml
@@ -37,6 +37,7 @@ dependencies:
   - chemper
   - geometric
   - torsiondrive
+  - pymbar <4
 
     # Executor
   - uvicorn

--- a/devtools/conda-envs/no_openeye.yaml
+++ b/devtools/conda-envs/no_openeye.yaml
@@ -39,6 +39,7 @@ dependencies:
   - chemper
   - geometric
   - torsiondrive
+  - pymbar <4
 
     # Executor
   - uvicorn

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -41,6 +41,7 @@ dependencies:
   - chemper
   - geometric
   - torsiondrive
+  - pymbar <4
 
     # Executor
   - uvicorn

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -22,7 +22,7 @@ dependencies:
   - click-option-group
   - rdkit
   - openff-utilities
-  - openff-toolkit-base >=0.10.0,!=0.10.3
+  - openff-toolkit-base >=0.10.0,!=0.10.3,<0.11
   - openff-forcefields
   - openff-qcsubmit
   - openmm >=7.6.0

--- a/openff/bespokefit/exceptions.py
+++ b/openff/bespokefit/exceptions.py
@@ -1,9 +1,6 @@
 """Exceptions for BespokeFit"""
 
 import traceback
-from typing import Set, Tuple
-
-from numpy.typing import NDArray
 
 
 class BespokeFitException(Exception):
@@ -151,40 +148,3 @@ class MissingTorsionTargetSMARTS(BespokeFitException):
 
     error_type = "missing_torsion_target_smarts"
     header = "Missing Torsion Target SMARTS"
-
-
-class TargetConnectivityChanged(BespokeFitException):
-    """
-    Raised when a target's reference data's connectivity has changed during QC
-    """
-
-    error_type = "target_connectivity_changed"
-    header = "Target Connectivity Changed"
-
-    def __init__(
-        self,
-        record_name: str,
-        fragment_smiles: str,
-        missing_connections: Set[Tuple[int, int]],
-        unexpected_connections: Set[Tuple[int, int]],
-        geometry: NDArray,
-    ):
-
-        message = (
-            f"Target record {record_name}: "
-            + "Reference data does not match target.\n"
-            + f"Expected mapped SMILES: {fragment_smiles}\n"
-            + "The following connections were expected but not found: "
-            + f"{missing_connections}\n"
-            + "The following connections were found but not expected: "
-            + f"{unexpected_connections}\n"
-            + f"The reference geometry is: {geometry}"
-        )
-
-        super().__init__(message)
-
-        self.record_name = record_name
-        self.fragment_smiles = fragment_smiles
-        self.missing_connections = missing_connections
-        self.unexpected_connections = unexpected_connections
-        self.geometry = geometry

--- a/openff/bespokefit/exceptions.py
+++ b/openff/bespokefit/exceptions.py
@@ -1,6 +1,9 @@
 """Exceptions for BespokeFit"""
 
 import traceback
+from typing import Tuple, Set
+
+from numpy.typing import NDArray
 
 
 class BespokeFitException(Exception):
@@ -148,3 +151,40 @@ class MissingTorsionTargetSMARTS(BespokeFitException):
 
     error_type = "missing_torsion_target_smarts"
     header = "Missing Torsion Target SMARTS"
+
+
+class TargetConnectivityChanged(BespokeFitException):
+    """
+    Raised when a target's reference data's connectivity has changed during QC
+    """
+
+    error_type = "target_connectivity_changed"
+    header = "Target Connectivity Changed"
+
+    def __init__(
+        self,
+        record_name: str,
+        fragment_smiles: str,
+        missing_connections: Set[Tuple[int, int]],
+        unexpected_connections: Set[Tuple[int, int]],
+        geometry: NDArray,
+    ):
+
+        message = (
+            f"Target record {record_name}: "
+            + "Reference data does not match target.\n"
+            + f"Expected mapped SMILES: {fragment_smiles}\n"
+            + "The following connections were expected but not found: "
+            + f"{missing_connections}\n"
+            + "The following connections were found but not expected: "
+            + f"{unexpected_connections}\n"
+            + f"The reference geometry is: {geometry}"
+        )
+
+        super().__init__(message)
+
+        self.record_name = record_name
+        self.fragment_smiles = fragment_smiles
+        self.missing_connections = missing_connections
+        self.unexpected_connections = unexpected_connections
+        self.geometry = geometry

--- a/openff/bespokefit/exceptions.py
+++ b/openff/bespokefit/exceptions.py
@@ -1,7 +1,7 @@
 """Exceptions for BespokeFit"""
 
 import traceback
-from typing import Tuple, Set
+from typing import Set, Tuple
 
 from numpy.typing import NDArray
 

--- a/openff/bespokefit/executor/services/coordinator/stages.py
+++ b/openff/bespokefit/executor/services/coordinator/stages.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import httpx
-from openff.fragmenter.fragment import Fragment, FragmentationResult, Molecule
+from openff.fragmenter.fragment import Fragment, FragmentationResult
 from openff.toolkit.typing.engines.smirnoff import (
     AngleHandler,
     BondHandler,

--- a/openff/bespokefit/executor/services/coordinator/stages.py
+++ b/openff/bespokefit/executor/services/coordinator/stages.py
@@ -15,7 +15,6 @@ from openff.toolkit.typing.engines.smirnoff import (
 )
 from pydantic import Field
 from qcelemental.models import AtomicResult, OptimizationResult
-from qcelemental.molutil import guess_connectivity
 from qcelemental.util import serialize
 from qcengine.procedures.torsiondrive import TorsionDriveResult
 from typing_extensions import Literal
@@ -533,34 +532,6 @@ class OptimizationStage(_Stage):
             )
 
             target.reference_data = local_qc_data
-
-            # Check that connectivity still matches the input molecule
-            for qc_record in local_qc_data.qc_records:
-                for name, qcschema in qc_record.final_molecules.items():
-                    fragment = Molecule.from_qcschema(qcschema)
-
-                    expected_connectivity = {
-                        tuple(sorted([bond.atom1_index + 1, bond.atom2_index + 1]))
-                        for bond in fragment.bonds
-                    }
-
-                    actual_connectivity = {
-                        tuple(sorted([a + 1, b + 1]))
-                        for a, b in guess_connectivity(
-                            qcschema.symbols, qcschema.geometry
-                        )
-                    }
-
-                    if expected_connectivity != actual_connectivity:
-                        raise RuntimeError(
-                            f"Target {qcschema.schema_name} record {name}: "
-                            + "Reference data does not match target.\n"
-                            + f"Expected mapped SMILES: {fragment.to_smiles(mapped=True)}\n"
-                            + "The following connections were expected but not found: "
-                            + f"{expected_connectivity - actual_connectivity}\n"
-                            + "The following connections were found but not expected: "
-                            + f"{actual_connectivity - expected_connectivity}\n"
-                        )
 
         targets_missing_qc_data = [
             target

--- a/openff/bespokefit/executor/services/coordinator/stages.py
+++ b/openff/bespokefit/executor/services/coordinator/stages.py
@@ -532,6 +532,7 @@ class OptimizationStage(_Stage):
             )
 
             target.reference_data = local_qc_data
+            target.validate_reference_data()
 
         targets_missing_qc_data = [
             target

--- a/openff/bespokefit/executor/services/coordinator/stages.py
+++ b/openff/bespokefit/executor/services/coordinator/stages.py
@@ -554,11 +554,11 @@ class OptimizationStage(_Stage):
                     if expected_connectivity != actual_connectivity:
                         raise RuntimeError(
                             f"Target {qcschema.schema_name} record {name}: "
-                            + f"Reference data does not match target.\n"
+                            + "Reference data does not match target.\n"
                             + f"Expected mapped SMILES: {fragment.to_smiles(mapped=True)}\n"
-                            + f"The following connections were expected but not found: "
+                            + "The following connections were expected but not found: "
                             + f"{expected_connectivity - actual_connectivity}\n"
-                            + f"The following connections were found but not expected: "
+                            + "The following connections were found but not expected: "
                             + f"{actual_connectivity - expected_connectivity}\n"
                         )
 

--- a/openff/bespokefit/executor/services/coordinator/stages.py
+++ b/openff/bespokefit/executor/services/coordinator/stages.py
@@ -532,7 +532,6 @@ class OptimizationStage(_Stage):
             )
 
             target.reference_data = local_qc_data
-            target.validate_reference_data()
 
         targets_missing_qc_data = [
             target

--- a/openff/bespokefit/schema/targets.py
+++ b/openff/bespokefit/schema/targets.py
@@ -10,14 +10,11 @@ from openff.toolkit.topology import Molecule
 from pydantic import Field, PositiveFloat
 from qcelemental.models import AtomicResult
 from qcelemental.models import Molecule as QCEMolecule
-from qcelemental.models.procedures import (
-    OptimizationResult,
-    TorsionDriveResult,
-)
+from qcelemental.models.procedures import OptimizationResult, TorsionDriveResult
 from qcelemental.molutil import guess_connectivity
 from typing_extensions import Literal
-from openff.bespokefit.exceptions import TargetConnectivityChanged
 
+from openff.bespokefit.exceptions import TargetConnectivityChanged
 from openff.bespokefit.schema.data import BespokeQCData, LocalQCData
 from openff.bespokefit.schema.tasks import (
     HessianTaskSpec,

--- a/openff/bespokefit/schema/targets.py
+++ b/openff/bespokefit/schema/targets.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Dict, Optional, Set, Tuple, TypeVar, Union
+from typing import Any, Dict, Optional, TypeVar, Union
 
 from openff.qcsubmit.results import (
     BasicResultCollection,
@@ -14,7 +14,6 @@ from qcelemental.models.procedures import OptimizationResult, TorsionDriveResult
 from qcelemental.molutil import guess_connectivity
 from typing_extensions import Literal
 
-from openff.bespokefit.exceptions import TargetConnectivityChanged
 from openff.bespokefit.schema.data import BespokeQCData, LocalQCData
 from openff.bespokefit.schema.tasks import (
     HessianTaskSpec,

--- a/openff/bespokefit/schema/targets.py
+++ b/openff/bespokefit/schema/targets.py
@@ -81,6 +81,7 @@ def _check_connectivity(
             + f"{expected_connectivity - actual_connectivity}\n"
             + "The following connections were found but not expected: "
             + f"{actual_connectivity - expected_connectivity}\n"
+            + f"The reference geometry is: {qcschema.geometry}"
         )
 
 

--- a/openff/bespokefit/schema/targets.py
+++ b/openff/bespokefit/schema/targets.py
@@ -1,12 +1,11 @@
 import abc
-from typing import Any, Dict, Optional, Set, TypeVar, Union
+from typing import Any, Dict, Optional, Set, TypeVar, Union, Tuple
 
 from openff.qcsubmit.results import (
     BasicResultCollection,
     OptimizationResultCollection,
     TorsionDriveResultCollection,
 )
-from openff.qcsubmit.results.results import Tuple
 from openff.toolkit.topology import Molecule
 from pydantic import Field, PositiveFloat, validator
 from qcelemental.models import AtomicResult

--- a/openff/bespokefit/schema/targets.py
+++ b/openff/bespokefit/schema/targets.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Set, Tuple, TypeVar, Union
 
 from openff.qcsubmit.results import (
     BasicResultCollection,
@@ -7,7 +7,7 @@ from openff.qcsubmit.results import (
     TorsionDriveResultCollection,
 )
 from openff.toolkit.topology import Molecule
-from pydantic import Field, PositiveFloat
+from pydantic import Field, PositiveFloat, validator
 from qcelemental.models import AtomicResult
 from qcelemental.models import Molecule as QCEMolecule
 from qcelemental.models.procedures import OptimizationResult, TorsionDriveResult
@@ -73,13 +73,78 @@ def _check_connectivity(
     }
 
     if expected_connectivity != actual_connectivity:
-        raise TargetConnectivityChanged(
-            record_name=name,
-            fragment_smiles=fragment.to_smiles(mapped=True),
-            missing_connections=expected_connectivity - actual_connectivity,
-            unexpected_connections=actual_connectivity - expected_connectivity,
-            geometry=qcschema.geometry,
+        # Pydantic validators must raise ValueError, TypeError or AssertionError
+        raise ValueError(
+            f"Target record {name}: "
+            + "Reference data does not match target.\n"
+            + f"Expected mapped SMILES: {fragment.to_smiles(mapped=True)}\n"
+            + "The following connections were expected but not found: "
+            + f"{expected_connectivity - actual_connectivity}\n"
+            + "The following connections were found but not expected: "
+            + f"{actual_connectivity - expected_connectivity}\n"
+            + f"The reference geometry is: {qcschema.geometry}"
         )
+
+
+R = TypeVar(
+    "R",
+    None,
+    LocalQCData[TorsionDriveResult],
+    LocalQCData[OptimizationResult],
+    BespokeQCData[Torsion1DTaskSpec],
+    BespokeQCData[OptimizationTaskSpec],
+    OptimizationResultCollection,
+    TorsionDriveResultCollection,
+)
+
+
+def _validate_connectivity(
+    cls,
+    ref_data: R,
+) -> R:
+    """
+    Check that connectivity has not changed over the course of QC computation.
+
+    This function can be used as a validator for the ``reference_data`` field of
+    a target schema if the connectivity may change over the course of computing
+    the target:
+
+        def __init__(...):
+            ...
+            _reference_data_connectivity = validator("reference_data", allow_reuse=True)(
+                _check_connectivity
+            )
+            ...
+
+    """
+    if isinstance(ref_data, LocalQCData):
+        for qc_record in ref_data.qc_records:
+            # Some qc records (eg, TorsionDriveResult) use .final_molecules (plural),
+            # others (eg, OptimizationResult) use .final_molecule (singular)
+            try:
+                final_molecules = qc_record.final_molecules
+            except AttributeError:
+                final_molecules = {"opt": qc_record.final_molecule}
+
+            for name, qcschema in final_molecules.items():
+                _check_connectivity(qcschema, name)
+
+    elif isinstance(
+        ref_data, (TorsionDriveResultCollection, OptimizationResultCollection)
+    ):
+        for qc_record, fragment in ref_data.to_records():
+            # Some qc records (eg, TorsionDriveRecord) use .get_final_molecules() (plural),
+            # others (eg, OptimizationRecord) use .get_final_molecule() (singular)
+            try:
+                final_molecules = qc_record.get_final_molecules()
+            except AttributeError:
+                final_molecules = {"opt": qc_record.get_final_molecule()}
+
+            for name, qcschema in final_molecules.items():
+                _check_connectivity(qcschema, name, fragment)
+
+    # No connectivity changes found, so return the unchanged input as validated
+    return ref_data
 
 
 class BaseTargetSchema(SchemaBase, abc.ABC):
@@ -112,64 +177,6 @@ class BaseTargetSchema(SchemaBase, abc.ABC):
         """
         raise NotImplementedError
 
-    def validate_reference_data(self) -> None:
-        """
-        Perform any required validations on the reference data.
-
-        We don't use Pydantic for this because it doesn't play nice with JSON
-        errors. Successfuly validation returns ``None``; unsuccessful
-        validation raises an error. The default implementation checks that
-        connectivity is unchanged after QM calculations; if this is not desired
-        in a subclass, override this method.
-        """
-        self._validate_connectivity()
-
-    def _validate_connectivity(
-        self,
-    ):
-        """
-        Check that connectivity has not changed over the course of QC computation.
-
-        This function can be used as a validator for the ``reference_data`` field of
-        a target schema if the connectivity may change over the course of computing
-        the target:
-
-            def __init__(...):
-                ...
-                _reference_data_connectivity = validator("reference_data", allow_reuse=True)(
-                    _check_connectivity
-                )
-                ...
-
-        """
-        ref_data = self.reference_data
-        if ref_data is None or isinstance(ref_data, BespokeQCData):
-            # Reference data has not been computed, so the connectivity is intact
-            return
-        elif isinstance(ref_data, LocalQCData):
-            for qc_record in ref_data.qc_records:
-                # Some qc records (eg, TorsionDriveResult) use .final_molecules (plural),
-                # others (eg, OptimizationResult) use .final_molecule (singular)
-                try:
-                    final_molecules = qc_record.final_molecules
-                except AttributeError:
-                    final_molecules = {"opt": qc_record.final_molecule}
-
-                for name, qcschema in final_molecules.items():
-                    _check_connectivity(qcschema, name)
-        elif hasattr(ref_data, "to_records"):
-            # Reference data is a QCSubmit result collection
-            for qc_record, fragment in ref_data.to_records():
-                # Some qc records (eg, TorsionDriveRecord) use .get_final_molecules() (plural),
-                # others (eg, OptimizationRecord) use .get_final_molecule() (singular)
-                try:
-                    final_molecules = qc_record.get_final_molecules()
-                except AttributeError:
-                    final_molecules = {"opt": qc_record.get_final_molecule()}
-
-                for name, qcschema in final_molecules.items():
-                    _check_connectivity(qcschema, name, fragment)
-
 
 class TorsionProfileTargetSchema(BaseTargetSchema):
     """A model which stores information about a torsion profile fitting target."""
@@ -186,6 +193,9 @@ class TorsionProfileTargetSchema(BaseTargetSchema):
         None,
         description="The reference QC data (either existing or to be generated on the "
         "fly) to fit against.",
+    )
+    _reference_data_connectivity = validator("reference_data", allow_reuse=True)(
+        _validate_connectivity
     )
     calculation_specification: Optional[Torsion1DTaskSpec] = Field(
         None,
@@ -221,6 +231,9 @@ class AbInitioTargetSchema(BaseTargetSchema):
         None,
         description="The reference QC data (either existing or to be generated on the "
         "fly) to fit against.",
+    )
+    _reference_data_connectivity = validator("reference_data", allow_reuse=True)(
+        _validate_connectivity
     )
     calculation_specification: Optional[Torsion1DTaskSpec] = Field(
         None,
@@ -272,12 +285,6 @@ class VibrationTargetSchema(BaseTargetSchema):
     def bespoke_task_type(cls) -> Literal["hessian"]:
         return "hessian"
 
-    def validate_reference_data(self) -> None:
-        """
-        Vibrations (currently) perform no geometry optimization, so no validation is necessary.
-        """
-        return None
-
 
 class OptGeoTargetSchema(BaseTargetSchema):
     """A model which stores information about an optimized geometry fitting target."""
@@ -294,6 +301,9 @@ class OptGeoTargetSchema(BaseTargetSchema):
         None,
         description="The reference QC data (either existing or to be generated on the "
         "fly) to fit against.",
+    )
+    _reference_data_connectivity = validator("reference_data", allow_reuse=True)(
+        _validate_connectivity
     )
     calculation_specification: Optional[OptimizationTaskSpec] = Field(
         None,

--- a/openff/bespokefit/schema/targets.py
+++ b/openff/bespokefit/schema/targets.py
@@ -88,6 +88,42 @@ def _check_connectivity(
                         + "The following connections were found but not expected: "
                         + f"{actual_connectivity - expected_connectivity}\n"
                     )
+
+    elif isinstance(
+        ref_data, (TorsionDriveResultCollection, OptimizationResultCollection)
+    ):
+        for qc_record, fragment in ref_data.to_records():
+            # Get correct connectivity from the schema's SMILES
+            expected_connectivity = {
+                tuple(sorted([bond.atom1_index + 1, bond.atom2_index + 1]))
+                for bond in fragment.bonds
+            }
+
+            # Some qc records (eg, TorsionDriveResult) use .final_molecules (plural),
+            # others (eg, OptimizationResult) use .final_molecule (singular)
+            try:
+                final_molecules = qc_record.get_final_molecules()
+            except AttributeError:
+                final_molecules = {"opt": qc_record.get_final_molecule()}
+
+            for name, qcschema in final_molecules.items():
+                # Get computed connectivity guessed from the output geometry
+                actual_connectivity = {
+                    tuple(sorted([a + 1, b + 1]))
+                    for a, b in guess_connectivity(qcschema.symbols, qcschema.geometry)
+                }
+
+                if expected_connectivity != actual_connectivity:
+                    # Pydantic validators must raise ValueError, TypeError or AssertionError
+                    raise ValueError(
+                        f"Target record {name}: "
+                        + "Reference data does not match target.\n"
+                        + f"Expected mapped SMILES: {fragment.to_smiles(mapped=True)}\n"
+                        + "The following connections were expected but not found: "
+                        + f"{expected_connectivity - actual_connectivity}\n"
+                        + "The following connections were found but not expected: "
+                        + f"{actual_connectivity - expected_connectivity}\n"
+                    )
     # No connectivity changes found, so return the unchanged input as validated
     return ref_data
 

--- a/openff/bespokefit/schema/targets.py
+++ b/openff/bespokefit/schema/targets.py
@@ -116,7 +116,10 @@ def _validate_connectivity(
             ...
 
     """
-    if isinstance(ref_data, LocalQCData):
+    if ref_data is None or isinstance(ref_data, BespokeQCData):
+        # Reference data has not been computed, so the connectivity is intact
+        return ref_data
+    elif isinstance(ref_data, LocalQCData):
         for qc_record in ref_data.qc_records:
             # Some qc records (eg, TorsionDriveResult) use .final_molecules (plural),
             # others (eg, OptimizationResult) use .final_molecule (singular)
@@ -128,9 +131,7 @@ def _validate_connectivity(
             for name, qcschema in final_molecules.items():
                 _check_connectivity(qcschema, name)
 
-    elif isinstance(
-        ref_data, (TorsionDriveResultCollection, OptimizationResultCollection)
-    ):
+    elif hasattr(ref_data, "to_records"):
         for qc_record, fragment in ref_data.to_records():
             # Some qc records (eg, TorsionDriveRecord) use .get_final_molecules() (plural),
             # others (eg, OptimizationRecord) use .get_final_molecule() (singular)

--- a/openff/bespokefit/schema/targets.py
+++ b/openff/bespokefit/schema/targets.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Dict, Optional, Set, TypeVar, Union, Tuple
+from typing import Any, Dict, Optional, Set, Tuple, TypeVar, Union
 
 from openff.qcsubmit.results import (
     BasicResultCollection,

--- a/openff/bespokefit/tests/schema/test_targets.py
+++ b/openff/bespokefit/tests/schema/test_targets.py
@@ -87,10 +87,16 @@ def test_check_connectivity_local_negative(
         + r"reference_data\n"
         + r"  Target record (opt|\[-165\]): Reference data "
         + r"does not match target\.\n"
-        + r"Expected mapped SMILES: \[H:13\]\[c:1\]1\[c:3\]\(\[c:7\]\(\[c:11\]"
-        + r"\(\[c:8\]\(\[c:4\]1\[H:16\]\)\[H:20\]\)\[c:12\]2\[c:9\]\(\[c:5\]\("
-        + r"\[c:2\]\(\[c:6\]\(\[c:10\]2\[H:22\]\)\[H:18\]\)\[H:14\]\)\[H:17\]\)"
-        + r"\[H:21\]\)\[H:19\]\)\[H:15\]\n"
+        + r"Expected mapped SMILES: "
+        # This regex for the mapped SMILES is probably extremely fragile;
+        # if this test breaks after an RDkit/OpenEye update, try replacing it
+        # with something like `+ r".*"`
+        + r"(\(?\[("
+        + r"H:13|c:1|c:3|c:7|c:11|c:8|c:4|H:16|H:20|c:12|c:9|c:5|c:2|c:6|c:10"
+        + r"|H:22|H:18|H:14|H:17|H:21|H:19|H:15"
+        + r")\]1?2?\)?){22}"
+        # End fragile regex
+        + r"\n"
         + r"The following connections were expected but not found: "
         + r"{\(1, 13\), \(1, 3\), \(1, 4\)}\n"
         + r"The following connections were found but not expected: "

--- a/openff/bespokefit/tests/schema/test_targets.py
+++ b/openff/bespokefit/tests/schema/test_targets.py
@@ -91,7 +91,7 @@ def test_check_connectivity_local_negative(
         # This regex for the mapped SMILES is probably extremely fragile;
         # if this test breaks after an RDkit/OpenEye update, try replacing it
         # with something like `+ r".*"`
-        + r"(\(?\[("
+        + r"(\(?[-+]?\[("
         + r"H:13|c:1|c:3|c:7|c:11|c:8|c:4|H:16|H:20|c:12|c:9|c:5|c:2|c:6|c:10"
         + r"|H:22|H:18|H:14|H:17|H:21|H:19|H:15"
         + r")\]1?2?\)?){22}"

--- a/openff/bespokefit/tests/schema/test_targets.py
+++ b/openff/bespokefit/tests/schema/test_targets.py
@@ -2,8 +2,12 @@ import pytest
 from pydantic import ValidationError
 from qcelemental.models.common_models import Model
 
-from openff.bespokefit.schema.data import BespokeQCData
-from openff.bespokefit.schema.targets import TorsionProfileTargetSchema
+from openff.bespokefit.schema.data import BespokeQCData, LocalQCData
+from openff.bespokefit.schema.targets import (
+    TorsionProfileTargetSchema,
+    AbInitioTargetSchema,
+    OptGeoTargetSchema,
+)
 from openff.bespokefit.schema.tasks import HessianTaskSpec, Torsion1DTaskSpec
 
 
@@ -30,4 +34,70 @@ def test_check_reference_data(qc_torsion_drive_results):
                     program="rdkit", model=Model(method="uff", basis=None)
                 )
             )
+        )
+
+
+@pytest.mark.parametrize(
+    "TargetSchema,qc_result_fixture",
+    [
+        (TorsionProfileTargetSchema, "qc_torsion_drive_qce_result"),
+        (AbInitioTargetSchema, "qc_torsion_drive_qce_result"),
+        (OptGeoTargetSchema, "qc_optimization_qce_result"),
+    ],
+)
+def test_check_connectivity_local_positive(
+    TargetSchema,
+    qc_result_fixture,
+    request,
+):
+    torsiondrive_result, _ = request.getfixturevalue(qc_result_fixture)
+
+    TargetSchema(reference_data=LocalQCData(qc_records=[torsiondrive_result]))
+
+
+@pytest.mark.parametrize(
+    "TargetSchema,qc_result_fixture",
+    [
+        (TorsionProfileTargetSchema, "qc_torsion_drive_qce_result"),
+        (AbInitioTargetSchema, "qc_torsion_drive_qce_result"),
+        (OptGeoTargetSchema, "qc_optimization_qce_result"),
+    ],
+)
+def test_check_connectivity_local_negative(
+    TargetSchema,
+    qc_result_fixture,
+    request,
+):
+    torsiondrive_result, _ = request.getfixturevalue(qc_result_fixture)
+
+    # Swap the first two atoms' coordinates to break their connectivity
+    torsiondrive_result_disconnection = torsiondrive_result.copy()
+    try:
+        geom = next(
+            iter(torsiondrive_result_disconnection.final_molecules.values())
+        ).geometry
+    except AttributeError:
+        geom = torsiondrive_result_disconnection.final_molecule.geometry
+    geom[0], geom[1] = geom[1], geom[0]
+
+    expected_err = (
+        r"1 validation error for "
+        + TargetSchema.__name__
+        + r"\n"
+        + r"reference_data\n"
+        + r"  Target record (opt|\[-165\]): Reference data "
+        + r"does not match target\.\n"
+        + r"Expected mapped SMILES: \[H:13\]\[c:1\]1\[c:3\]\(\[c:7\]\(\[c:11\]"
+        + r"\(\[c:8\]\(\[c:4\]1\[H:16\]\)\[H:20\]\)\[c:12\]2\[c:9\]\(\[c:5\]\("
+        + r"\[c:2\]\(\[c:6\]\(\[c:10\]2\[H:22\]\)\[H:18\]\)\[H:14\]\)\[H:17\]\)"
+        + r"\[H:21\]\)\[H:19\]\)\[H:15\]\n"
+        + r"The following connections were expected but not found: "
+        + r"{\(1, 13\), \(1, 3\), \(1, 4\)}\n"
+        + r"The following connections were found but not expected: "
+        + r"{\(1, 6\), \(1, 2\), \(1, 14\), \(1, 5\)}\n"
+        + r" \(type=value_error\)"
+    )
+    with pytest.raises(ValidationError, match=expected_err):
+        TargetSchema(
+            reference_data=LocalQCData(qc_records=[torsiondrive_result_disconnection])
         )

--- a/openff/bespokefit/tests/schema/test_targets.py
+++ b/openff/bespokefit/tests/schema/test_targets.py
@@ -1,8 +1,8 @@
 import pytest
 from pydantic import ValidationError
 from qcelemental.models.common_models import Model
-from openff.bespokefit.exceptions import TargetConnectivityChanged
 
+from openff.bespokefit.exceptions import TargetConnectivityChanged
 from openff.bespokefit.schema.data import BespokeQCData, LocalQCData
 from openff.bespokefit.schema.targets import (
     AbInitioTargetSchema,

--- a/openff/bespokefit/tests/schema/test_targets.py
+++ b/openff/bespokefit/tests/schema/test_targets.py
@@ -176,10 +176,16 @@ def test_check_connectivity_qcfractal_negative(
         + r"reference_data\n"
         + r"  Target record (opt|\[-165\]): Reference data "
         + r"does not match target\.\n"
-        + r"Expected mapped SMILES: \[H:13\]\[c:1\]1\[c:3\]\(\[c:7\]\(\[c:11\]"
-        + r"\(\[c:8\]\(\[c:4\]1\[H:16\]\)\[H:20\]\)\[c:12\]2\[c:9\]\(\[c:5\]\("
-        + r"\[c:2\]\(\[c:6\]\(\[c:10\]2\[H:22\]\)\[H:18\]\)\[H:14\]\)\[H:17\]\)"
-        + r"\[H:21\]\)\[H:19\]\)\[H:15\]\n"
+        + r"Expected mapped SMILES: "
+        # This regex for the mapped SMILES is probably extremely fragile;
+        # if this test breaks after an RDkit/OpenEye update, try replacing it
+        # with something like `+ r".*"`
+        + r"(\(?\[("
+        + r"H:13|c:1|c:3|c:7|c:11|c:8|c:4|H:16|H:20|c:12|c:9|c:5|c:2|c:6|c:10"
+        + r"|H:22|H:18|H:14|H:17|H:21|H:19|H:15"
+        + r")\]1?2?\)?){22}"
+        # End fragile regex
+        + r"\n"
         + r"The following connections were expected but not found: "
         + r"{\(1, 13\), \(1, 3\), \(1, 4\)}\n"
         + r"The following connections were found but not expected: "

--- a/openff/bespokefit/tests/schema/test_targets.py
+++ b/openff/bespokefit/tests/schema/test_targets.py
@@ -38,159 +38,128 @@ def test_check_reference_data(qc_torsion_drive_results):
 
 
 @pytest.mark.parametrize(
-    "TargetSchema,qc_result_fixture",
+    "TargetSchema",
     [
-        (TorsionProfileTargetSchema, "qc_torsion_drive_qce_result"),
-        (AbInitioTargetSchema, "qc_torsion_drive_qce_result"),
-        (OptGeoTargetSchema, "qc_optimization_qce_result"),
+        TorsionProfileTargetSchema,
+        AbInitioTargetSchema,
+        OptGeoTargetSchema,
     ],
 )
-def test_check_connectivity_local_positive(
-    TargetSchema,
-    qc_result_fixture,
-    request,
-):
-    torsiondrive_result, _ = request.getfixturevalue(qc_result_fixture)
-
-    TargetSchema(reference_data=LocalQCData(qc_records=[torsiondrive_result]))
-
-
-@pytest.mark.parametrize(
-    "TargetSchema,qc_result_fixture",
-    [
-        (TorsionProfileTargetSchema, "qc_torsion_drive_qce_result"),
-        (AbInitioTargetSchema, "qc_torsion_drive_qce_result"),
-        (OptGeoTargetSchema, "qc_optimization_qce_result"),
-    ],
-)
-def test_check_connectivity_local_negative(
-    TargetSchema,
-    qc_result_fixture,
-    request,
-):
-    torsiondrive_result, _ = request.getfixturevalue(qc_result_fixture)
-
-    # Swap the first two atoms' coordinates to break their connectivity
-    torsiondrive_result_disconnection = torsiondrive_result.copy()
-    try:
-        geom = next(
-            iter(torsiondrive_result_disconnection.final_molecules.values())
-        ).geometry
-    except AttributeError:
-        geom = torsiondrive_result_disconnection.final_molecule.geometry
-    geom[0], geom[1] = geom[1], geom[0]
-
-    expected_err = (
-        r"1 validation error for "
-        + TargetSchema.__name__
-        + r"\n"
-        + r"reference_data\n"
-        + r"  Target record (opt|\[-165\]): Reference data "
-        + r"does not match target\.\n"
-        + r"Expected mapped SMILES: "
-        # This regex for the mapped SMILES is probably extremely fragile;
-        # if this test breaks after an RDkit/OpenEye update, try replacing it
-        # with something like `+ r".*"`
-        + r"(\(?[-+]?\[("
-        + r"H:13|c:1|c:3|c:7|c:11|c:8|c:4|H:16|H:20|c:12|c:9|c:5|c:2|c:6|c:10"
-        + r"|H:22|H:18|H:14|H:17|H:21|H:19|H:15"
-        + r")\]1?2?\)?){22}"
-        # End fragile regex
-        + r"\n"
-        + r"The following connections were expected but not found: "
-        + r"{\(1, 13\), \(1, 3\), \(1, 4\)}\n"
-        + r"The following connections were found but not expected: "
-        + r"{\(1, 6\), \(1, 2\), \(1, 14\), \(1, 5\)}\n"
-        + r" \(type=value_error\)"
-    )
-    with pytest.raises(ValidationError, match=expected_err):
-        TargetSchema(
-            reference_data=LocalQCData(qc_records=[torsiondrive_result_disconnection])
+class TestCheckConnectivity:
+    @pytest.fixture()
+    def expected_err(self, TargetSchema) -> str:
+        return (
+            r"1 validation error for "
+            + TargetSchema.__name__
+            + r"\n"
+            + r"reference_data\n"
+            + r"  Target record (opt|\[-165\]): Reference data "
+            + r"does not match target\.\n"
+            + r"Expected mapped SMILES: "
+            # This regex for the mapped SMILES is probably extremely fragile;
+            # if this test breaks after an RDkit/OpenEye update, try replacing it
+            # with something like `+ r".*"`
+            + r"(\(?[-+]?\[("
+            + r"H:13|c:1|c:3|c:7|c:11|c:8|c:4|H:16|H:20|c:12|c:9|c:5|c:2|c:6|c:10"
+            + r"|H:22|H:18|H:14|H:17|H:21|H:19|H:15"
+            + r")\]1?2?\)?){22}"
+            # End fragile regex
+            + r"\n"
+            + r"The following connections were expected but not found: "
+            + r"{\(1, 13\), \(1, 3\), \(1, 4\)}\n"
+            + r"The following connections were found but not expected: "
+            + r"{\(1, 6\), \(1, 2\), \(1, 14\), \(1, 5\)}\n"
+            + r" \(type=value_error\)"
         )
 
+    @pytest.fixture()
+    def ref_data_local(self, TargetSchema, request):
+        ref_data_fixture = {
+            TorsionProfileTargetSchema: "qc_torsion_drive_qce_result",
+            AbInitioTargetSchema: "qc_torsion_drive_qce_result",
+            OptGeoTargetSchema: "qc_optimization_qce_result",
+        }[TargetSchema]
+        result, _ = request.getfixturevalue(ref_data_fixture)
+        return [result]
 
-@pytest.mark.parametrize(
-    "TargetSchema,qc_result_fixture",
-    [
-        (TorsionProfileTargetSchema, "qc_torsion_drive_results"),
-        (AbInitioTargetSchema, "qc_torsion_drive_results"),
-        (OptGeoTargetSchema, "qc_optimization_results"),
-    ],
-)
-def test_check_connectivity_qcfractal_positive(
-    TargetSchema,
-    qc_result_fixture,
-    request,
-):
-    torsiondrive_result_collection = request.getfixturevalue(qc_result_fixture)
+    @pytest.fixture()
+    def ref_data_qcfractal(self, TargetSchema, request):
+        ref_data_fixture = {
+            TorsionProfileTargetSchema: "qc_torsion_drive_results",
+            AbInitioTargetSchema: "qc_torsion_drive_results",
+            OptGeoTargetSchema: "qc_optimization_results",
+        }[TargetSchema]
+        return request.getfixturevalue(ref_data_fixture)
 
-    TargetSchema(reference_data=torsiondrive_result_collection)
+    def test_check_connectivity_local_positive(
+        self,
+        TargetSchema,
+        ref_data_local,
+    ):
+        TargetSchema(reference_data=LocalQCData(qc_records=ref_data_local))
 
+    def test_check_connectivity_local_negative(
+        self,
+        TargetSchema,
+        ref_data_local,
+        expected_err,
+    ):
+        # Swap the first two atoms' coordinates to break their connectivity
+        torsiondrive_result_disconnection = ref_data_local[0]
+        try:
+            geom = next(
+                iter(torsiondrive_result_disconnection.final_molecules.values())
+            ).geometry
+        except AttributeError:
+            geom = torsiondrive_result_disconnection.final_molecule.geometry
+        geom[0], geom[1] = geom[1], geom[0]
 
-@pytest.mark.parametrize(
-    "TargetSchema,qc_result_fixture",
-    [
-        (TorsionProfileTargetSchema, "qc_torsion_drive_results"),
-        (AbInitioTargetSchema, "qc_torsion_drive_results"),
-        (OptGeoTargetSchema, "qc_optimization_results"),
-    ],
-)
-def test_check_connectivity_qcfractal_negative(
-    TargetSchema,
-    qc_result_fixture,
-    request,
-):
-    collection = request.getfixturevalue(qc_result_fixture)
+        with pytest.raises(ValidationError, match=expected_err):
+            TargetSchema(
+                reference_data=LocalQCData(
+                    qc_records=[torsiondrive_result_disconnection]
+                )
+            )
 
-    [(record, _)] = collection.to_records()
+    def test_check_connectivity_qcfractal_positive(
+        self,
+        TargetSchema,
+        ref_data_qcfractal,
+    ):
+        TargetSchema(reference_data=ref_data_qcfractal)
 
-    # Get the first of the final molecules, and prepare an update function so
-    # that changes are preserved across calls to get_final_molecule(s)()
-    try:
-        final_molecules = record.get_final_molecules()
-        key, first_final_mol = next(iter(record.cache["final_molecules"].items()))
+    def test_check_connectivity_qcfractal_negative(
+        self,
+        TargetSchema,
+        ref_data_qcfractal,
+        expected_err,
+    ):
+        [(record, _)] = ref_data_qcfractal.to_records()
 
-        def update_record(updated_mol):
-            final_molecules.update({key: updated_mol})
-            record.__dict__["get_final_molecules"] = lambda: final_molecules
+        # Get the first of the final molecules, and prepare an update function so
+        # that changes are preserved across calls to get_final_molecule(s)()
+        try:
+            final_molecules = record.get_final_molecules()
+            key, first_final_mol = next(iter(record.cache["final_molecules"].items()))
 
-    except AttributeError:
-        first_final_mol = record.get_final_molecule()
+            def update_record(updated_mol):
+                final_molecules.update({key: updated_mol})
+                record.__dict__["get_final_molecules"] = lambda: final_molecules
 
-        def update_record(updated_mol):
-            record.__dict__["get_final_molecule"] = lambda: updated_mol
+        except AttributeError:
+            first_final_mol = record.get_final_molecule()
 
-    # Swap the first two atoms' coordinates to break their connectivity
-    geom = first_final_mol.geometry.copy()
-    geom[0], geom[1] = geom[1], geom[0]
-    updated_mol = first_final_mol.copy(update={"geometry": geom})
+            def update_record(updated_mol):
+                record.__dict__["get_final_molecule"] = lambda: updated_mol
 
-    # Update the record with the new geometry
-    update_record(updated_mol)
+        # Swap the first two atoms' coordinates to break their connectivity
+        geom = first_final_mol.geometry.copy()
+        geom[0], geom[1] = geom[1], geom[0]
+        updated_mol = first_final_mol.copy(update={"geometry": geom})
 
-    # Create the target schema, which should fail to validate
-    expected_err = (
-        r"1 validation error for "
-        + TargetSchema.__name__
-        + r"\n"
-        + r"reference_data\n"
-        + r"  Target record (opt|\[-165\]): Reference data "
-        + r"does not match target\.\n"
-        + r"Expected mapped SMILES: "
-        # This regex for the mapped SMILES is probably extremely fragile;
-        # if this test breaks after an RDkit/OpenEye update, try replacing it
-        # with something like `+ r".*"`
-        + r"(\(?[-+]?\[("
-        + r"H:13|c:1|c:3|c:7|c:11|c:8|c:4|H:16|H:20|c:12|c:9|c:5|c:2|c:6|c:10"
-        + r"|H:22|H:18|H:14|H:17|H:21|H:19|H:15"
-        + r")\]1?2?\)?){22}"
-        # End fragile regex
-        + r"\n"
-        + r"The following connections were expected but not found: "
-        + r"{\(1, 13\), \(1, 3\), \(1, 4\)}\n"
-        + r"The following connections were found but not expected: "
-        + r"{\(1, 6\), \(1, 2\), \(1, 14\), \(1, 5\)}\n"
-        + r" \(type=value_error\)"
-    )
-    with pytest.raises(ValidationError, match=expected_err):
-        TargetSchema(reference_data=collection)
+        # Update the record with the new geometry
+        update_record(updated_mol)
+
+        # Create the target schema, which should fail to validate
+        with pytest.raises(ValidationError, match=expected_err):
+            TargetSchema(reference_data=ref_data_qcfractal)

--- a/openff/bespokefit/tests/schema/test_targets.py
+++ b/openff/bespokefit/tests/schema/test_targets.py
@@ -180,7 +180,7 @@ def test_check_connectivity_qcfractal_negative(
         # This regex for the mapped SMILES is probably extremely fragile;
         # if this test breaks after an RDkit/OpenEye update, try replacing it
         # with something like `+ r".*"`
-        + r"(\(?\[("
+        + r"(\(?[-+]?\[("
         + r"H:13|c:1|c:3|c:7|c:11|c:8|c:4|H:16|H:20|c:12|c:9|c:5|c:2|c:6|c:10"
         + r"|H:22|H:18|H:14|H:17|H:21|H:19|H:15"
         + r")\]1?2?\)?){22}"

--- a/openff/bespokefit/tests/schema/test_targets.py
+++ b/openff/bespokefit/tests/schema/test_targets.py
@@ -2,7 +2,6 @@ import pytest
 from pydantic import ValidationError
 from qcelemental.models.common_models import Model
 
-from openff.bespokefit.exceptions import TargetConnectivityChanged
 from openff.bespokefit.schema.data import BespokeQCData, LocalQCData
 from openff.bespokefit.schema.targets import (
     AbInitioTargetSchema,

--- a/openff/bespokefit/tests/schema/test_targets.py
+++ b/openff/bespokefit/tests/schema/test_targets.py
@@ -69,6 +69,8 @@ class TestCheckConnectivity:
             + r"{\(1, 13\), \(1, 3\), \(1, 4\)}\n"
             + r"The following connections were found but not expected: "
             + r"{\(1, 6\), \(1, 2\), \(1, 14\), \(1, 5\)}\n"
+            + r"The reference geometry is: \[(\[.*\]\n ){21}\[.*\]\]"
+            # + r"The reference geometry is: \[.*\]"
             + r" \(type=value_error\)"
         )
 

--- a/openff/bespokefit/tests/schema/test_targets.py
+++ b/openff/bespokefit/tests/schema/test_targets.py
@@ -4,9 +4,9 @@ from qcelemental.models.common_models import Model
 
 from openff.bespokefit.schema.data import BespokeQCData, LocalQCData
 from openff.bespokefit.schema.targets import (
-    TorsionProfileTargetSchema,
     AbInitioTargetSchema,
     OptGeoTargetSchema,
+    TorsionProfileTargetSchema,
 )
 from openff.bespokefit.schema.tasks import HessianTaskSpec, Torsion1DTaskSpec
 


### PR DESCRIPTION
## Description
This PR addresses #189 by causing a clear error or warning and appropriately discarding data when the connectivity of the molecule being fitted changes. The goal is for connectivity changes to log a warning and fall back to initial force field parameters.

I'm opening this PR for discussion but it's a work in progress. At the moment it seems to work - SMILES `CCCC` completes successfully while SMILES `[NH3+]CC[O-]` and aminolevulinicacid.sdf from #189 raise the desired exception.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Identify when connectivity changes occur in QC generation
  - [x] Raise an exception on connectivity changes
  - [ ] ~~Identify when connectivity changes occur before QC generation (fragmentation?)~~
  - [ ] ~~Warn user that connectivity changes have occurred~~
  - [ ] ~~Skip targets where connectivity changes occur instead of raising exception~~
  - [x] Tests

## Questions
- [ ] ~~What's the best way to log a warning without failing the run?~~
- [x] A close inspection of #189 reveals that in the example provided, and in our minimized reproduction, the input coordinates to the torsion run have already undergone proton transfer. Where in code does this happen? I'm guessing when the fragmentation happens, but haven't found it yet
- [x] What's the best way to test this? I'm thinking a unit test of `OptimizationStage._inject_bespoke_qc_data()` plus an integration test of a number of molecules known both to and not to undergo a proton transfer, but this might be quite slow?
- [ ] ~~Are there currently any integration tests that will at least succeed if no connectivity change occurs?~~

## Status
- [x] Ready to go