### PR TITLE
Support OpenFF Toolkit v0.11+

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -81,7 +81,7 @@ jobs:
       - name: Run Tests
         shell: bash -l {0}
         run: |
-          pytest -v --cov=openff --cov-config=setup.cfg openff/bespokefit/tests/ --cov-report=xml
+          pytest -v --cov=openff --cov-config=setup.cfg openff/bespokefit/tests/executor/services/coordinator/test_app.py::test_get_optimization --cov-report=xml
 
       - name: Codecov
         uses: codecov/codecov-action@v3.1.1

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Run Tests
         shell: bash -l {0}
         run: |
-          pytest -v --cov=openff --cov-config=setup.cfg openff/bespokefit/tests/executor/services/coordinator/test_app.py::test_get_optimization --cov-report=xml
+          pytest -v --cov=openff --cov-config=setup.cfg openff/bespokefit/tests --cov-report=xml
 
       - name: Codecov
         uses: codecov/codecov-action@v3.1.1

--- a/.github/workflows/Lint.yaml
+++ b/.github/workflows/Lint.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run isort
         run: |
-          isort --recursive --check-only openff
+          isort --check-only openff
 
       - name: Run black
         run: |

--- a/devtools/conda-envs/docs-env.yaml
+++ b/devtools/conda-envs/docs-env.yaml
@@ -18,7 +18,7 @@ dependencies:
   - click-option-group
   - rdkit
   - openff-utilities
-  - openff-toolkit-base >=0.11.0
+  - openff-toolkit-base >=0.11.3
   - openff-forcefields
   - openff-qcsubmit
   - openmm >=7.6.0
@@ -32,8 +32,8 @@ dependencies:
     ### Bespoke dependencies
 
   - qcportal >=0.15.6
-  - qcelemental >=0.24.0
-  - qcengine >=0.21.0
+  - qcelemental >=0.25.1
+  - qcengine >=0.25
   - chemper
   - geometric
   - torsiondrive

--- a/devtools/conda-envs/docs-env.yaml
+++ b/devtools/conda-envs/docs-env.yaml
@@ -18,7 +18,7 @@ dependencies:
   - click-option-group
   - rdkit
   - openff-utilities
-  - openff-toolkit-base >=0.10.0
+  - openff-toolkit-base >=0.11.0
   - openff-forcefields
   - openff-qcsubmit
   - openmm >=7.6.0

--- a/devtools/conda-envs/docs-env.yaml
+++ b/devtools/conda-envs/docs-env.yaml
@@ -20,12 +20,12 @@ dependencies:
   - openff-utilities
   - openff-toolkit-base >=0.11.3
   - openff-forcefields
-  - openff-qcsubmit >=0.4
+  - openff-qcsubmit
   - openmm >=7.6.0
 
     # Optional
-  - forcebalance >=1.9.2
-  - openff-fragmenter-base >=0.1.2
+  - forcebalance
+  - openff-fragmenter-base
 
   - openeye-toolkits
 
@@ -37,7 +37,7 @@ dependencies:
   - chemper
   - geometric
   - torsiondrive
-  - pymbar <4
+  - pymbar
 
     # Executor
   - uvicorn

--- a/devtools/conda-envs/docs-env.yaml
+++ b/devtools/conda-envs/docs-env.yaml
@@ -20,7 +20,7 @@ dependencies:
   - openff-utilities
   - openff-toolkit-base >=0.11.3
   - openff-forcefields
-  - openff-qcsubmit
+  - openff-qcsubmit >=0.4
   - openmm >=7.6.0
 
     # Optional

--- a/devtools/conda-envs/no_openeye.yaml
+++ b/devtools/conda-envs/no_openeye.yaml
@@ -22,7 +22,7 @@ dependencies:
   - rdkit >=22
   - ambertools >=22
   - openff-utilities
-  - openff-toolkit-base =0.11
+  - openff-toolkit-base >=0.11.3
   - openff-forcefields >=2.0.0
   - openff-qcsubmit >=0.3.0
   - openmm >=7.6.0
@@ -34,8 +34,8 @@ dependencies:
     ### Bespoke dependencies
 
   - qcportal >=0.15.6
-  - qcelemental >=0.24.0
-  - qcengine >=0.23.0
+  - qcelemental >=0.25.1
+  - qcengine >=0.25
   - chemper
   - geometric
   - torsiondrive
@@ -60,6 +60,4 @@ dependencies:
 
   # Temporary branches
   - pip:
-    - git+https://github.com/openforcefield/openff-toolkit.git@main
     - git+https://github.com/yoshanuikabundi/openff-qcsubmit.git@toolkit_011_support
-    - git+https://github.com/Yoshanuikabundi/QCEngine.git@off_toolkit_011_support

--- a/devtools/conda-envs/no_openeye.yaml
+++ b/devtools/conda-envs/no_openeye.yaml
@@ -23,13 +23,13 @@ dependencies:
   - ambertools >=22
   - openff-utilities
   - openff-toolkit-base >=0.11.3
-  - openff-forcefields >=2.0.0
-  - openff-qcsubmit >=0.4.0
+  - openff-forcefields
+  - openff-qcsubmit
   - openmm >=7.6.0
 
     # Optional
-  - forcebalance >=1.9.2
-  - openff-fragmenter-base >=0.1.2
+  - forcebalance
+  - openff-fragmenter-base
 
     ### Bespoke dependencies
 
@@ -39,7 +39,7 @@ dependencies:
   - chemper
   - geometric
   - torsiondrive
-  - pymbar <4
+  - pymbar
 
     # Executor
   - uvicorn

--- a/devtools/conda-envs/no_openeye.yaml
+++ b/devtools/conda-envs/no_openeye.yaml
@@ -60,6 +60,6 @@ dependencies:
 
   # Temporary branches
   - pip:
-    - git+https://github.com/openforcefield/openff-toolkit.git@deepcopy_properties
+    - git+https://github.com/openforcefield/openff-toolkit.git@main
     - git+https://github.com/yoshanuikabundi/openff-qcsubmit.git@toolkit_011_support
     - git+https://github.com/Yoshanuikabundi/QCEngine.git@off_toolkit_011_support

--- a/devtools/conda-envs/no_openeye.yaml
+++ b/devtools/conda-envs/no_openeye.yaml
@@ -24,7 +24,7 @@ dependencies:
   - openff-utilities
   - openff-toolkit-base >=0.11.3
   - openff-forcefields >=2.0.0
-  - openff-qcsubmit >=0.3.0
+  - openff-qcsubmit >=0.4.0
   - openmm >=7.6.0
 
     # Optional
@@ -57,7 +57,3 @@ dependencies:
   - pytest-celery
   - codecov
   - requests-mock
-
-  # Temporary branches
-  - pip:
-    - git+https://github.com/yoshanuikabundi/openff-qcsubmit.git@toolkit_011_support

--- a/devtools/conda-envs/no_openeye.yaml
+++ b/devtools/conda-envs/no_openeye.yaml
@@ -22,7 +22,7 @@ dependencies:
   - rdkit >=22
   - ambertools >=22
   - openff-utilities
-  - openff-toolkit-base =0.10.6
+  - openff-toolkit-base =0.11
   - openff-forcefields >=2.0.0
   - openff-qcsubmit >=0.3.0
   - openmm >=7.6.0

--- a/devtools/conda-envs/no_openeye.yaml
+++ b/devtools/conda-envs/no_openeye.yaml
@@ -57,3 +57,9 @@ dependencies:
   - pytest-celery
   - codecov
   - requests-mock
+
+  # Temporary branches
+  - pip:
+    - git+https://github.com/openforcefield/openff-toolkit.git@deepcopy_properties
+    - git+https://github.com/yoshanuikabundi/openff-qcsubmit.git@toolkit_011_support
+    - git+https://github.com/Yoshanuikabundi/QCEngine.git@off_toolkit_011_support

--- a/devtools/conda-envs/no_openeye.yaml
+++ b/devtools/conda-envs/no_openeye.yaml
@@ -64,4 +64,4 @@ dependencies:
   - requests-mock
 
   - importlib-metadata >=4
-  - importlib_metadata >=4
+

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -22,8 +22,9 @@ dependencies:
   - click-option-group
   - rdkit
   - openff-utilities
-  - openff-toolkit-base >=0.10.0,!=0.10.3,<0.11
+  - openff-toolkit-base >=0.11
   - openff-forcefields
+  - openff-units
   - openff-qcsubmit
   - openmm >=7.6.0
 

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -46,7 +46,7 @@ dependencies:
 
     # Executor
   - uvicorn
-  - fastapi
+  - fastapi =0.85
   - celery
   - httpx
   - redis-server

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -63,6 +63,6 @@ dependencies:
 
   # Temporary branches
   - pip:
-    - git+https://github.com/openforcefield/openff-toolkit.git@deepcopy_properties
+    - git+https://github.com/openforcefield/openff-toolkit.git@main
     - git+https://github.com/yoshanuikabundi/openff-qcsubmit.git@toolkit_011_support
     - git+https://github.com/Yoshanuikabundi/QCEngine.git@off_toolkit_011_support

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -25,12 +25,12 @@ dependencies:
   - openff-toolkit-base >=0.11.3
   - openff-forcefields
   - openff-units
-  - openff-qcsubmit >=0.4
+  - openff-qcsubmit
   - openmm >=7.6.0
 
     # Optional
-  - forcebalance >=1.9.2
-  - openff-fragmenter-base >=0.1.2
+  - forcebalance
+  - openff-fragmenter-base
 
   - openeye-toolkits
 
@@ -42,7 +42,7 @@ dependencies:
   - chemper
   - geometric
   - torsiondrive
-  - pymbar <4
+  - pymbar
 
     # Executor
   - uvicorn

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -22,7 +22,7 @@ dependencies:
   - click-option-group
   - rdkit
   - openff-utilities
-  - openff-toolkit-base >=0.11
+  - openff-toolkit-base >=0.11.3
   - openff-forcefields
   - openff-units
   - openff-qcsubmit
@@ -37,8 +37,8 @@ dependencies:
     ### Bespoke dependencies
 
   - qcportal >=0.15.6
-  - qcelemental >=0.24.0
-  - qcengine >=0.23.0
+  - qcelemental >=0.25.1
+  - qcengine >=0.25
   - chemper
   - geometric
   - torsiondrive
@@ -63,6 +63,4 @@ dependencies:
 
   # Temporary branches
   - pip:
-    - git+https://github.com/openforcefield/openff-toolkit.git@main
     - git+https://github.com/yoshanuikabundi/openff-qcsubmit.git@toolkit_011_support
-    - git+https://github.com/Yoshanuikabundi/QCEngine.git@off_toolkit_011_support

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -50,12 +50,8 @@ dependencies:
 
     # Executor
   - uvicorn
-<<<<<<< HEAD
-  - fastapi =0.85
-=======
   - fastapi
   - starlette =0.20 # https://github.com/openforcefield/openff-bespokefit/pull/203#issuecomment-1315936000
->>>>>>> upstream/main
   - celery
   - httpx
   - redis-server

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -60,3 +60,9 @@ dependencies:
   - pytest-celery
   - codecov
   - requests-mock
+
+  # Temporary branches
+  - pip:
+    - git+https://github.com/openforcefield/openff-toolkit.git@deepcopy_properties
+    - git+https://github.com/yoshanuikabundi/openff-qcsubmit.git@toolkit_011_support
+    - git+https://github.com/Yoshanuikabundi/QCEngine.git@off_toolkit_011_support

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -25,7 +25,7 @@ dependencies:
   - openff-toolkit-base >=0.11.3
   - openff-forcefields
   - openff-units
-  - openff-qcsubmit
+  - openff-qcsubmit >=0.4
   - openmm >=7.6.0
 
     # Optional
@@ -60,7 +60,3 @@ dependencies:
   - pytest-celery
   - codecov
   - requests-mock
-
-  # Temporary branches
-  - pip:
-    - git+https://github.com/yoshanuikabundi/openff-qcsubmit.git@toolkit_011_support

--- a/openff/bespokefit/cli/combine.py
+++ b/openff/bespokefit/cli/combine.py
@@ -3,7 +3,8 @@ from typing import List, Optional
 
 import click
 import rich
-from openff.toolkit.typing.engines.smirnoff import ForceField, ParameterLookupError
+from openff.toolkit import ForceField
+from openff.toolkit.utils.exceptions import ParameterLookupError
 from rich import pretty
 from rich.padding import Padding
 

--- a/openff/bespokefit/optimizers/forcebalance/factories.py
+++ b/openff/bespokefit/optimizers/forcebalance/factories.py
@@ -310,7 +310,7 @@ class AbInitioTargetFactory(_TargetFactory[AbInitioTargetSchema]):
         fb_molecule.Data = {
             "resname": ["UNK"] * off_molecule.n_atoms,
             "resid": [0] * off_molecule.n_atoms,
-            "elem": [atom.element.symbol for atom in off_molecule.atoms],
+            "elem": [atom.symbol for atom in off_molecule.atoms],
             "bonds": [
                 (bond.atom1_index, bond.atom2_index) for bond in off_molecule.bonds
             ],
@@ -542,7 +542,7 @@ class VibrationTargetFactory(_TargetFactory[VibrationTargetSchema]):
         fb_molecule.Data = {
             "resname": ["UNK"] * off_molecule.n_atoms,
             "resid": [0] * off_molecule.n_atoms,
-            "elem": [atom.element.symbol for atom in off_molecule.atoms],
+            "elem": [atom.symbol for atom in off_molecule.atoms],
             "bonds": [
                 (bond.atom1_index, bond.atom2_index) for bond in off_molecule.bonds
             ],
@@ -615,7 +615,7 @@ class OptGeoTargetFactory(_TargetFactory[OptGeoTargetSchema]):
             fb_molecule.Data = {
                 "resname": ["UNK"] * off_molecule.n_atoms,
                 "resid": [0] * off_molecule.n_atoms,
-                "elem": [atom.element.symbol for atom in off_molecule.atoms],
+                "elem": [atom.symbol for atom in off_molecule.atoms],
                 "bonds": [
                     (bond.atom1_index, bond.atom2_index) for bond in off_molecule.bonds
                 ],

--- a/openff/bespokefit/optimizers/forcebalance/factories.py
+++ b/openff/bespokefit/optimizers/forcebalance/factories.py
@@ -15,12 +15,12 @@ from openff.qcsubmit.results import (
 from openff.toolkit.topology import Molecule
 from openff.toolkit.topology import Molecule as OFFMolecule
 from openff.toolkit.typing.engines.smirnoff import ForceField
+from openff.units import unit
 from openff.utilities import temporary_cd
 from qcelemental.models import AtomicResult
 from qcelemental.models.procedures import OptimizationResult, TorsionDriveResult
 from qcportal.models import TorsionDriveRecord
 from qcportal.models.records import OptimizationRecord, RecordBase, ResultRecord
-from simtk import unit
 
 from openff.bespokefit.exceptions import OptimizerError, QCRecordMissMatchError
 from openff.bespokefit.optimizers.forcebalance.templates import (
@@ -297,7 +297,7 @@ class AbInitioTargetFactory(_TargetFactory[AbInitioTargetSchema]):
             raise NotImplementedError()
 
         grid_conformers = {
-            tuple(json.loads(grid_id)): conformer.value_in_unit(unit.angstrom)
+            tuple(json.loads(grid_id)): conformer.m_as(unit.angstrom)
             for grid_id, conformer in zip(
                 off_molecule.properties["grid_ids"], off_molecule.conformers
             )
@@ -488,7 +488,7 @@ class VibrationTargetFactory(_TargetFactory[VibrationTargetSchema]):
 
         # Get the list of masses for the molecule to be consistent with ForceBalance
         masses = np.array(
-            [atom.mass.value_in_unit(unit.dalton) for atom in off_molecule.atoms]
+            [atom.mass.m_as(unit.dalton) for atom in off_molecule.atoms]
         )
 
         # Compute the mass-weighted hessian
@@ -547,7 +547,7 @@ class VibrationTargetFactory(_TargetFactory[VibrationTargetSchema]):
                 (bond.atom1_index, bond.atom2_index) for bond in off_molecule.bonds
             ],
             "name": f"{qc_record_id}",
-            "xyzs": [off_molecule.conformers[0].value_in_unit(unit.angstrom)],
+            "xyzs": [off_molecule.conformers[0].m_as(unit.angstrom)],
         }
 
         # form a Molecule object from the first torsion grid data
@@ -620,7 +620,7 @@ class OptGeoTargetFactory(_TargetFactory[OptGeoTargetSchema]):
                     (bond.atom1_index, bond.atom2_index) for bond in off_molecule.bonds
                 ],
                 "name": f"{qc_record_id}",
-                "xyzs": [off_molecule.conformers[0].value_in_unit(unit.angstrom)],
+                "xyzs": [off_molecule.conformers[0].m_as(unit.angstrom)],
             }
 
             fb_molecule.write(f"{record_name}.pdb")

--- a/openff/bespokefit/optimizers/forcebalance/factories.py
+++ b/openff/bespokefit/optimizers/forcebalance/factories.py
@@ -487,9 +487,7 @@ class VibrationTargetFactory(_TargetFactory[VibrationTargetSchema]):
             )
 
         # Get the list of masses for the molecule to be consistent with ForceBalance
-        masses = np.array(
-            [atom.mass.m_as(unit.dalton) for atom in off_molecule.atoms]
-        )
+        masses = np.array([atom.mass.m_as(unit.dalton) for atom in off_molecule.atoms])
 
         # Compute the mass-weighted hessian
         invert_sqrt_mass_array_repeat = 1.0 / np.sqrt(masses.repeat(3))

--- a/openff/bespokefit/optimizers/forcebalance/forcebalance.py
+++ b/openff/bespokefit/optimizers/forcebalance/forcebalance.py
@@ -168,6 +168,14 @@ class ForceBalanceOptimizer(BaseOptimizer):
 
         result = {"error": None}
 
+        try:
+            with open(os.path.join(root_directory, "optimize.err")) as err:
+                errlog = err.read()
+                if "Traceback" in errlog:
+                    raise ValueError(f"ForceBalance job failed: {errlog}")
+        except IOError:
+            pass
+
         with open(os.path.join(root_directory, "optimize.out")) as log:
 
             for line in log.readlines():

--- a/openff/bespokefit/schema/fitting.py
+++ b/openff/bespokefit/schema/fitting.py
@@ -4,8 +4,8 @@ from typing import Dict, List, Optional
 from openff.fragmenter.fragment import WBOFragmenter
 from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff import ForceField
+from openff.units import unit
 from pydantic import Field, conlist
-from simtk import unit
 from typing_extensions import Literal
 
 from openff.bespokefit.fragmentation import FragmentationEngine

--- a/openff/bespokefit/schema/results.py
+++ b/openff/bespokefit/schema/results.py
@@ -2,8 +2,8 @@ import abc
 from typing import Any, Dict, List, Optional
 
 from openff.toolkit.typing.engines.smirnoff import ForceField
+from openff.units import unit
 from pydantic import Field
-from simtk import unit
 from typing_extensions import Literal
 
 from openff.bespokefit.schema import Error, Status

--- a/openff/bespokefit/tests/conftest.py
+++ b/openff/bespokefit/tests/conftest.py
@@ -16,6 +16,7 @@ from openff.qcsubmit.results import (
 )
 from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff import ForceField
+from openff.units import unit
 from openff.utilities import get_data_file_path
 from qcelemental.models import AtomicResult
 from qcelemental.models.common_models import Model, Provenance
@@ -32,7 +33,6 @@ from qcportal.models import (
     ResultRecord,
     TorsionDriveRecord,
 )
-from simtk import unit
 
 from openff.bespokefit.executor.utilities.redis import (
     expected_redis_config_version,

--- a/openff/bespokefit/tests/executor/services/qcgenerator/test_app.py
+++ b/openff/bespokefit/tests/executor/services/qcgenerator/test_app.py
@@ -145,7 +145,7 @@ def test_get_qc_result(
     [
         (
             Torsion1DTask(
-                smiles="[CH2:1][CH2:2]",
+                smiles="[CH2:1]=[CH2:2]",
                 central_bond=(1, 2),
                 program="rdkit",
                 model=Model(method="uff", basis=None),
@@ -154,7 +154,7 @@ def test_get_qc_result(
         ),
         (
             OptimizationTask(
-                smiles="[CH2:1][CH2:2]",
+                smiles="[CH2:1]=[CH2:2]",
                 n_conformers=1,
                 program="rdkit",
                 model=Model(method="uff", basis=None),
@@ -163,7 +163,7 @@ def test_get_qc_result(
         ),
         (
             HessianTask(
-                smiles="[CH2:1][CH2:2]",
+                smiles="[CH2:1]=[CH2:2]",
                 program="rdkit",
                 model=Model(method="uff", basis=None),
             ),

--- a/openff/bespokefit/tests/executor/services/qcgenerator/test_cache.py
+++ b/openff/bespokefit/tests/executor/services/qcgenerator/test_cache.py
@@ -31,7 +31,7 @@ def test_canonicalize_torsion_task():
     [
         (
             Torsion1DTask(
-                smiles="[CH2:1][CH2:2]",
+                smiles="[CH2:1]=[CH2:2]",
                 central_bond=(1, 2),
                 program="rdkit",
                 model=Model(method="uff", basis=None),
@@ -40,7 +40,7 @@ def test_canonicalize_torsion_task():
         ),
         (
             OptimizationTask(
-                smiles="[CH2:1][CH2:2]",
+                smiles="[CH2:1]=[CH2:2]",
                 n_conformers=1,
                 program="rdkit",
                 model=Model(method="uff", basis=None),
@@ -49,7 +49,7 @@ def test_canonicalize_torsion_task():
         ),
         (
             HessianTask(
-                smiles="[CH2:1][CH2:2]",
+                smiles="[CH2:1]=[CH2:2]",
                 program="rdkit",
                 model=Model(method="uff", basis=None),
             ),

--- a/openff/bespokefit/tests/optimizers/forcebalance/test_forcebalance.py
+++ b/openff/bespokefit/tests/optimizers/forcebalance/test_forcebalance.py
@@ -159,8 +159,8 @@ def test_forcebalance_collect_general_results(
             initial_value = initial_values[parameter_smirks][attribute]
             refit_value = refit_values[parameter_smirks][attribute]
 
-            refit_value = refit_value.value_in_unit(initial_value.unit)
-            initial_value = initial_value.value_in_unit(initial_value.unit)
+            refit_value = refit_value.m_as(initial_value.units)
+            initial_value = initial_value.m_as(initial_value.units)
 
             assert not np.isclose(initial_value, refit_value)
 

--- a/openff/bespokefit/tests/schema/test_results.py
+++ b/openff/bespokefit/tests/schema/test_results.py
@@ -1,4 +1,4 @@
-from simtk import unit
+from openff.units import unit
 
 
 def test_initial_parameter_values(bespoke_optimization_results):

--- a/openff/bespokefit/tests/utilities/test_smirks.py
+++ b/openff/bespokefit/tests/utilities/test_smirks.py
@@ -10,8 +10,8 @@ from openff.toolkit.typing.engines.smirnoff import (
     ProperTorsionHandler,
     vdWHandler,
 )
+from openff.units import unit
 from openff.utilities import get_data_file_path
-from openmm import unit
 
 from openff.bespokefit.exceptions import SMIRKSTypeError
 from openff.bespokefit.schema.smirnoff import validate_smirks
@@ -113,7 +113,7 @@ def test_get_cached_torsion(bace):
     assert "cached" in cached_parameter._cosmetic_attribs
     # make sure the k value is updated
     assert cached_parameter.k[0] == unit.Quantity(
-        value=0.9155269008137, unit=unit.kilocalories_per_mole
+        0.9155269008137, unit.kilocalories_per_mole
     )
     # make sure the smirks has not changed
     assert cached_parameter.smirks == "[#6H1:1]@[#6:2]-!@[#6:3]@[#6H1:4]"

--- a/openff/bespokefit/tests/utilities/test_smirnoff.py
+++ b/openff/bespokefit/tests/utilities/test_smirnoff.py
@@ -6,8 +6,8 @@ import os
 
 import numpy as np
 from openff.toolkit.topology import Molecule
+from openff.units import unit
 from openff.utilities import get_data_file_path
-from simtk import unit
 
 from openff.bespokefit.schema.smirnoff import (
     AngleSMIRKS,
@@ -48,14 +48,14 @@ def test_adding_new_smirks_types():
     assert np.isclose(
         ff.force_field["vdW"]
         .parameters[new_parameter.smirks]
-        .rmin_half.value_in_unit(unit.angstrom),
+        .rmin_half.m_as(unit.angstrom),
         123.0,
     )
     assert np.isclose(
         ff.force_field["vdW"]
         .parameters[existing_parameter.smirks]
-        .rmin_half.value_in_unit(unit.angstrom),
-        existing_parameter.rmin_half.value_in_unit(unit.angstrom),
+        .rmin_half.m_as(unit.angstrom),
+        existing_parameter.rmin_half.m_as(unit.angstrom),
     )
 
 
@@ -141,7 +141,7 @@ def test_get_initial_parameters():
             if not isinstance(new_parameter[key], unit.Quantity):
                 continue
 
-            new_value = new_parameter[key].value_in_unit(old_parameter[key].unit)
-            old_value = old_parameter[key].value_in_unit(old_parameter[key].unit)
+            new_value = new_parameter[key].m_as(old_parameter[key].units)
+            old_value = old_parameter[key].m_as(old_parameter[key].units)
 
             assert np.isclose(new_value, old_value)

--- a/openff/bespokefit/utilities/smirks.py
+++ b/openff/bespokefit/utilities/smirks.py
@@ -7,8 +7,8 @@ from chemper.graphs.environment import ChemicalEnvironment
 from openff.fragmenter.utils import get_atom_index
 from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff import ParameterType, ProperTorsionHandler
+from openff.units import unit
 from pydantic import Field
-from simtk import unit
 from typing_extensions import Literal
 
 from openff.bespokefit.exceptions import SMIRKSTypeError

--- a/openff/bespokefit/utilities/smirnoff.py
+++ b/openff/bespokefit/utilities/smirnoff.py
@@ -6,17 +6,17 @@ from enum import Enum
 from typing import TYPE_CHECKING, Dict, List, Tuple, Union
 
 import numpy as np
-from openff.toolkit import topology as off
+from openff.toolkit import Molecule
 from openff.toolkit.typing.engines.smirnoff import (
     AngleHandler,
     BondHandler,
     ForceField,
     ImproperTorsionHandler,
-    ParameterLookupError,
     ParameterType,
     ProperTorsionHandler,
     vdWHandler,
 )
+from openff.toolkit.utils.exceptions import ParameterLookupError
 
 if TYPE_CHECKING:
     from openff.bespokefit.schema.smirnoff import SMIRNOFFParameter
@@ -116,7 +116,7 @@ class ForceFieldEditor:
         return added_parameters
 
     def label_molecule(
-        self, molecule: off.Molecule
+        self, molecule: Molecule
     ) -> Dict[str, Dict[Tuple[int, ...], ParameterType]]:
         """
         Type the molecule with the forcefield and return a molecule parameter dictionary.
@@ -131,7 +131,7 @@ class ForceFieldEditor:
         return self.force_field.label_molecules(molecule.to_topology())[0]
 
     def get_parameters(
-        self, molecule: off.Molecule, atoms_by_type: Dict[str, List[Tuple[int, ...]]]
+        self, molecule: Molecule, atoms_by_type: Dict[str, List[Tuple[int, ...]]]
     ) -> List[ParameterType]:
         """
         For a given molecule label it and get back the smirks patterns and parameters
@@ -153,7 +153,7 @@ class ForceFieldEditor:
 
     def get_initial_parameters(
         self,
-        molecule: off.Molecule,
+        molecule: Molecule,
         smirks: List["SMIRNOFFParameter"],
     ) -> List[ParameterType]:
         """


### PR DESCRIPTION
## Description
Update BespokeFit to work with new versions of the OpenFF Toolkit

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Add pins for Toolkit v0.11+
  - [x] Transition to OpenFF Units
  - [x] Update for breaking changes in 0.11+
  - [x] Check `optimize.err` for errors in force balance handler
  - [x] Set minimum versions of toolkit, qcsubmit, and qcengine once they are released (see status)

## Status
- [x] Requires https://github.com/openforcefield/openff-qcsubmit/pull/204 in a release on conda forge
- [x] Requires https://github.com/openforcefield/openff-toolkit/issues/1420 to be fixed in a release on conda forge
- [x] Requires https://github.com/leeping/forcebalance/pull/259 in a release on conda forge (passes tests without this)
- [x] New ForceBalance release
- [x] Ready to go