### PR TITLE
Test with geomeTRIC 1.0

### DIFF
--- a/devtools/conda-envs/no_openeye.yaml
+++ b/devtools/conda-envs/no_openeye.yaml
@@ -41,7 +41,7 @@ dependencies:
   - qcelemental >=0.25.1
   - qcengine >=0.25
   - chemper
-  - geometric <1
+  - geometric =1
   - torsiondrive
   - pymbar
 

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -44,7 +44,7 @@ dependencies:
   - qcelemental >=0.25.1
   - qcengine >=0.25
   - chemper
-  - geometric <1
+  - geometric =1
   - torsiondrive
   - pymbar
 


### PR DESCRIPTION
I forget why this pin was in place; I think it was for indirect compatibility and not due to an API change in 1.0.