### PR TITLE
Add a barebones integration test to CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -22,7 +22,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
         python-version: [3.8]
         openeye: [true, false]
-        integration: [true, false]
+        integration: [true]
 
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt
@@ -67,13 +67,11 @@ jobs:
           conda list
 
       - name: Run Tests
-        if: ${{ matrix.integration == false }}
         shell: bash -l {0}
         run: |
           pytest -v --cov=openff --cov-config=setup.cfg openff/bespokefit/tests --cov-report=xml
 
       - name: Codecov
-        if: ${{ matrix.integration == false }}
         uses: codecov/codecov-action@v3.1.1
         with:
           file: ./coverage.xml

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   test:
 
-    name: ${{ matrix.os }}, 🐍=${{ matrix.python-version }}, 👁️=${{ matrix.openeye }}
+    name: ${{ matrix.os }}, 🐍=${{ matrix.python-version }}, 👁️=${{ matrix.openeye }}, ∫=${{ matrix.integration }}
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -22,6 +22,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
         python-version: [3.8]
         openeye: [true, false]
+        integration: [true, false]
 
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt
@@ -66,12 +67,23 @@ jobs:
           conda list
 
       - name: Run Tests
+        if: ${{ matrix.integration == false }}
         shell: bash -l {0}
         run: |
           pytest -v --cov=openff --cov-config=setup.cfg openff/bespokefit/tests --cov-report=xml
 
       - name: Codecov
+        if: ${{ matrix.integration == false }}
         uses: codecov/codecov-action@v3.1.1
         with:
           file: ./coverage.xml
           fail_ci_if_error: false
+
+      - name: Run Integration Tests
+        if: ${{ matrix.integration == true }}
+        shell: bash -l {0}
+        run: |
+          openff-bespoke executor run --smiles                 'CC'               \
+                                      --workflow               'default'          \
+                                      --default-qc-spec        xtb gfn2xtb none   \
+                                      --target-torsion         '[C:1]-[C:2]'

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ ENV/
 
 # BespokeFit
 bespoke-executor/
+output.json

--- a/devtools/conda-envs/docs-env.yaml
+++ b/devtools/conda-envs/docs-env.yaml
@@ -20,6 +20,7 @@ dependencies:
   - openff-utilities
   - openff-toolkit-base >=0.11.3
   - openff-forcefields
+  - openff-interchange
   - openff-qcsubmit
   - openmm >=7.6.0
 

--- a/devtools/conda-envs/no_openeye.yaml
+++ b/devtools/conda-envs/no_openeye.yaml
@@ -34,6 +34,7 @@ dependencies:
     # Optional
   - forcebalance
   - openff-fragmenter-base
+  - xtb-python
 
     ### Bespoke dependencies
 

--- a/devtools/conda-envs/no_openeye.yaml
+++ b/devtools/conda-envs/no_openeye.yaml
@@ -24,6 +24,7 @@ dependencies:
   - openff-utilities
   - openff-toolkit-base >=0.11.3
   - openff-forcefields
+  - openff-interchange
   - openff-qcsubmit
   - openmm >=7.6.0
 

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -35,7 +35,7 @@ dependencies:
     # Optional
   - forcebalance
   - openff-fragmenter-base
-
+  - xtb-python
   - openeye-toolkits
 
     ### Bespoke dependencies

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -24,6 +24,7 @@ dependencies:
   - openff-utilities
   - openff-toolkit-base >=0.11.3
   - openff-forcefields
+  - openff-interchange
   - openff-units
   - openff-qcsubmit
   - openmm >=7.6.0

--- a/openff/bespokefit/cli/executor/run.py
+++ b/openff/bespokefit/cli/executor/run.py
@@ -118,7 +118,7 @@ def _run_cli(
 
                 results.bespoke_force_field.to_file(output_force_field_path)
 
-        if error_state["has_errored"]:
+        if error_state["has_errored"] or results.status == "errored":
             raise click.exceptions.Exit(code=2)
 
 


### PR DESCRIPTION
## Description
This is a barebones integration test for CI. It just runs the following fit:

```shell
openff-bespoke executor run --smiles                 'CC'               \
                            --workflow               'default'          \
                            --default-qc-spec        xtb gfn2xtb none   \
                            --target-torsion         '[C:1]-[C:2]'
```

This requires adding `xtb-python` to the test environment.

Integration tests are added to the testing matrix so that existing unit tests don't take longer; instead, there are 4 additional checks. Once I see what the timing is like on this PR, I'll probably adjust this.

This PR partially mitigates #218 but does not close it.