### PR TITLE
Add important information to bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,6 +1,9 @@
 ---
 name: Bug report
 about: Report a bug involving BespokeFit
+title: ''
+labels: ''
+assignees: ''
 
 ---
 
@@ -20,4 +23,11 @@ Please include the output, including full tracebacks of any errors, resulting fr
 
 - Which operating system and version are you using?
 - How did you install BespokeFit?
+- Are you using Apple Silicon? If so, are you running BespokeFit in Rosetta or directly?
 - What is the output of running `conda list`?
+
+<details><summary>Output of <code>conda list</code></summary><pre>
+
+Please place the output of `conda list` here
+
+</pre></details>

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -23,7 +23,7 @@ Please include the output, including full tracebacks of any errors, resulting fr
 
 - Which operating system and version are you using?
 - How did you install BespokeFit?
-- Are you using Apple Silicon? If so, are you running BespokeFit in Rosetta or directly?
+- Are you using Apple Silicon? If so, are you running BespokeFit in Rosetta (`osx-64`) or natively (`osx-arm64`)?
 - What is the output of running `conda list`?
 
 <details><summary>Output of <code>conda list</code></summary><pre>

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,6 +1,9 @@
 ---
 name: Feature request
-about: Suggest an improvement to BespokeFit 
+about: Suggest an improvement to BespokeFit
+title: ''
+labels: ''
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/USER_SUPPORT.md
+++ b/.github/ISSUE_TEMPLATE/USER_SUPPORT.md
@@ -1,6 +1,9 @@
 ---
 name: User support
 about: Ask for help using BespokeFit
+title: ''
+labels: ''
+assignees: ''
 
 ---
 
@@ -12,4 +15,11 @@ Please describe what you are trying to do, what you have done so far, and what y
 
 - Which operating system and version are you using?
 - How did you install BespokeFit?
+- Are you using Apple Silicon? If so, are you running BespokeFit in Rosetta or directly?
 - What is the output of running `conda list`?
+
+<details><summary>Output of <code>conda list</code></summary><pre>
+
+Please place the output of `conda list` here
+
+</pre></details>


### PR DESCRIPTION
Add a question about Apple Silicon and a <details> tag for `conda list` output to the Bug Report and User Support issue templates.