### PR TITLE
Fix #237

### DIFF
--- a/openff/bespokefit/utilities/molecule.py
+++ b/openff/bespokefit/utilities/molecule.py
@@ -92,12 +92,6 @@ def canonical_order_atoms(molecule: Molecule):
     atom_map = {i: rank for i, rank in enumerate(atom_order)}
 
     molecule = molecule.remap(atom_map, current_to_new=True)
-
-    if "atom_map" in molecule.properties:
-        molecule.properties["atom_map"] = {
-            atom_map[i]: j for i, j in molecule.properties["atom_map"].items()
-        }
-
     return molecule
 
 


### PR DESCRIPTION
## Description

In https://github.com/openforcefield/openff-toolkit/pull/1498 we introduced helpful logic to reindex the keys for any values in `offmol.properties['atom_map']` so that they correspond to the new ordering. It turns out that [BespokeFit ALSO did this](https://github.com/openforcefield/openff-bespokefit/blob/1b8763838c8070a4abee253bd72d66a40b3dacaf/openff/bespokefit/utilities/molecule.py#L96-L99), leading to a double-reindexing, which the tests caught and are warning us about. This can be fixed by removing the now-redundant logic from BespokeFit. 

## Todos
  - [ ] Resolve #237
  - [ ] Update releasehistory

## Status
- [ ] Ready to go