### PR TITLE
Worker launch CLI

### DIFF
--- a/devtools/conda-envs/no_openeye.yaml
+++ b/devtools/conda-envs/no_openeye.yaml
@@ -21,7 +21,6 @@ dependencies:
   - click-option-group
   - rdkit >=22
   - ambertools >=22
-  - pint <0.22
   - openff-utilities
   - openff-toolkit-base >=0.11,<0.14
   - openff-forcefields

--- a/devtools/conda-envs/no_openeye.yaml
+++ b/devtools/conda-envs/no_openeye.yaml
@@ -21,8 +21,9 @@ dependencies:
   - click-option-group
   - rdkit >=22
   - ambertools >=22
+  - pint <0.22
   - openff-utilities
-  - openff-toolkit-base =0.11
+  - openff-toolkit-base >=0.11,<0.14
   - openff-forcefields
   - openff-interchange
   - openff-qcsubmit

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -21,7 +21,6 @@ dependencies:
   - click
   - click-option-group
   - rdkit
-  - pint <0.22
   - openff-utilities
   - openff-toolkit-base >=0.11,<0.14
   - openff-forcefields

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -21,8 +21,9 @@ dependencies:
   - click
   - click-option-group
   - rdkit
+  - pint <0.22
   - openff-utilities
-  - openff-toolkit-base =0.11
+  - openff-toolkit-base >=0.11,<0.14
   - openff-forcefields
   - openff-interchange
   - openff-units

--- a/docs/users/bespoke-executor.md
+++ b/docs/users/bespoke-executor.md
@@ -64,7 +64,52 @@ different stages may run in parallel.
 
 See the [quick start guide](quick_start_chapter) for details on submitting jobs to a running bespoke executor.
 
+(executor_distributed_workers)=
+## Distributed Workers
+
+Bespokefit is able to make use of distributed resources across HPC clusters or multiple machines on the same network via
+the [Celery] framework which underpins the workers. In this example we assume the workers and bespoke executor are on 
+different machines. First gather the IP address of the machine which will be running the bespoke executor
+
+```shell
+ifconfig -a
+```
+
+A bespoke executor with no local workers can then be launched using the `launch` command
+
+```shell
+openff-bespoke executor launch --directory            "bespoke-executor" \
+                               --n-fragmenter-workers 0                  \
+                               --n-optimizer-workers  0                  \
+                               --n-qc-compute-workers 0
+```
+
+We now need to provide the address of the executor inorder to connect the remote workers. BespokeFit has a number of run 
+time [settings] which can be configured via environment variables. The address of the executor should be set to 
+`BEFLOW_REDIS_ADDRESS` in the environment the workers will be launched from using
+
+```shell
+export BEFLOW_REDIS_ADDRESS="address"
+```
+
+Bespoke workers of a given type can then be launched using the `launch-worker` command, the following would start a
+fragmentation worker.
+
+```shell
+openff-bespoke launch-worker --worker-type fragmenter
+```
+
+Provided the worker starts successfully a log file will be generated called `celery-fragmenter.log` which should be 
+checked to make sure the worker has connected to the executor.
+
+:::{note}
+The `launch-worker` command does not allow for configuration of the worker resources, it is recommended that the 
+corresponding environment variable [settings] are used instead.
+:::
+
+
 [QCEngine]: http://docs.qcarchive.molssi.org/projects/QCEngine/en/stable/
+[settings]: openff.bespokefit.utilities.Settings
 
 (executor_using_api)=
 ## Using the API

--- a/openff/bespokefit/cli/cli.py
+++ b/openff/bespokefit/cli/cli.py
@@ -4,6 +4,7 @@ from openff.bespokefit.cli.cache import cache_cli
 from openff.bespokefit.cli.combine import combine_cli
 from openff.bespokefit.cli.executor import executor_cli
 from openff.bespokefit.cli.prepare import prepare_cli
+from openff.bespokefit.cli.worker import worker_cli
 
 
 @click.group()
@@ -15,3 +16,4 @@ cli.add_command(executor_cli)
 cli.add_command(prepare_cli)
 cli.add_command(cache_cli)
 cli.add_command(combine_cli)
+cli.add_command(worker_cli)

--- a/openff/bespokefit/cli/executor/launch.py
+++ b/openff/bespokefit/cli/executor/launch.py
@@ -112,7 +112,9 @@ def validate_redis_connection(console: "rich.Console", allow_existing: bool = Tr
     settings = current_settings()
 
     if not is_redis_available(
-        host=settings.BEFLOW_REDIS_ADDRESS, port=settings.BEFLOW_REDIS_PORT
+        host=settings.BEFLOW_REDIS_ADDRESS,
+        port=settings.BEFLOW_REDIS_PORT,
+        password=settings.BEFLOW_REDIS_PASSWORD,
     ):
         return
 

--- a/openff/bespokefit/cli/worker.py
+++ b/openff/bespokefit/cli/worker.py
@@ -20,13 +20,18 @@ worker_types = ["fragmenter", "qc-compute", "optimizer"]
 )
 def worker_cli(worker_type: str):
     """
-    Launch a single worker of the requested type in the main process. Used to connect workers to a remote bespokefit server.
+    Launch a single worker of the requested type in the main process.
 
-    By default bespokefit will automatically use all cores and memory made available to the worker which should
-    be declared in the job submission script. To change these defaults see the settings `BEFLOW_QC_COMPUTE_WORKER_N_CORES` &
-    `BEFLOW_QC_COMPUTE_WORKER_MAX_MEM`.
+    Used to connect workers to a remote bespokefit server.
+
+    Note:
+
+        By default bespokefit will automatically use all cores and memory made available to the worker which should
+        be declared in the job submission script. To change these defaults see the settings `BEFLOW_QC_COMPUTE_WORKER_N_CORES` &
+        `BEFLOW_QC_COMPUTE_WORKER_MAX_MEM`.
 
     Args:
+
         worker_type: The alias name of the worker type which should be started.
     """
 

--- a/openff/bespokefit/cli/worker.py
+++ b/openff/bespokefit/cli/worker.py
@@ -1,0 +1,57 @@
+import importlib
+
+import click
+import rich
+from rich import pretty
+
+from openff.bespokefit.cli.utilities import print_header
+from openff.bespokefit.executor.services import current_settings
+from openff.bespokefit.executor.utilities.celery import spawn_worker
+
+worker_types = ["fragmenter", "qc-compute", "optimizer"]
+
+
+@click.command("launch-worker")
+@click.option(
+    "--worker-type",
+    type=click.Choice(worker_types),
+    help="The type of bespokefit worker to launch",
+    required=True,
+)
+def worker_cli(worker_type: str):
+    """
+    Launch a single worker of the requested type in the main process. Used to connect workers to a remote bespokefit server.
+
+    By default bespokefit will automatically use all cores and memory made available to the worker which should
+    be declared in the job submission script. To change these defaults see the settings `BEFLOW_QC_COMPUTE_WORKER_N_CORES` &
+    `BEFLOW_QC_COMPUTE_WORKER_MAX_MEM`.
+
+    Args:
+        worker_type: The alias name of the worker type which should be started.
+    """
+
+    pretty.install()
+
+    console = rich.get_console()
+    print_header(console)
+
+    worker_status = console.status(f"launching {worker_type} worker")
+    worker_status.start()
+
+    settings = current_settings()
+
+    if worker_type == "fragmenter":
+        worker_settings = settings.fragmenter_settings
+    elif worker_type == "qc-compute":
+        worker_settings = settings.qc_compute_settings
+    else:
+        worker_settings = settings.optimizer_settings
+
+    worker_module = importlib.import_module(worker_settings.import_path)
+    importlib.reload(worker_module)
+    worker_app = getattr(worker_module, "celery_app")
+
+    worker_status.stop()
+    console.print(f"[[green]✓[/green]] bespoke {worker_type} worker launched")
+
+    spawn_worker(worker_app, concurrency=1, asynchronous=False)

--- a/openff/bespokefit/executor/services/optimizer/worker.py
+++ b/openff/bespokefit/executor/services/optimizer/worker.py
@@ -82,7 +82,9 @@ def optimize(self, optimization_input_json: str) -> str:
     # cache the final parameters
     if (
         is_redis_available(
-            host=settings.BEFLOW_REDIS_ADDRESS, port=settings.BEFLOW_REDIS_PORT
+            host=settings.BEFLOW_REDIS_ADDRESS,
+            port=settings.BEFLOW_REDIS_PORT,
+            password=settings.BEFLOW_REDIS_PASSWORD,
         )
         and result.refit_force_field is not None
     ):

--- a/openff/bespokefit/executor/utilities/celery.py
+++ b/openff/bespokefit/executor/utilities/celery.py
@@ -9,6 +9,7 @@ from typing_extensions import TypedDict
 
 from openff.bespokefit.executor.services.models import Error
 from openff.bespokefit.executor.utilities.typing import Status
+from openff.bespokefit.utilities import current_settings
 
 
 class TaskInformation(TypedDict):
@@ -33,11 +34,12 @@ def get_status(task_result: AsyncResult) -> Status:
 def configure_celery_app(
     app_name: str, redis_connection: Redis, include: List[str] = None
 ):
+    settings = current_settings()
     redis_host_name = redis_connection.connection_pool.connection_kwargs["host"]
     redis_port = redis_connection.connection_pool.connection_kwargs["port"]
     redis_db = redis_connection.connection_pool.connection_kwargs["db"]
     username = redis_connection.connection_pool.connection_kwargs["username"]
-    password = redis_connection.connection_pool.connection_kwargs["password"]
+    password = settings.BEFLOW_REDIS_PASSWORD
 
     celery_app = Celery(
         app_name,

--- a/openff/bespokefit/executor/utilities/celery.py
+++ b/openff/bespokefit/executor/utilities/celery.py
@@ -38,13 +38,12 @@ def configure_celery_app(
     redis_host_name = redis_connection.connection_pool.connection_kwargs["host"]
     redis_port = redis_connection.connection_pool.connection_kwargs["port"]
     redis_db = redis_connection.connection_pool.connection_kwargs["db"]
-    username = redis_connection.connection_pool.connection_kwargs["username"]
     password = settings.BEFLOW_REDIS_PASSWORD
 
     celery_app = Celery(
         app_name,
-        backend=f"redis://{username}:{password}@{redis_host_name}:{redis_port}/{redis_db}",
-        broker=f"redis://{username}:{password}@{redis_host_name}:{redis_port}/{redis_db}",
+        backend=f"redis://:{password}@{redis_host_name}:{redis_port}/{redis_db}",
+        broker=f"redis://:{password}@{redis_host_name}:{redis_port}/{redis_db}",
         include=include,
     )
 

--- a/openff/bespokefit/executor/utilities/celery.py
+++ b/openff/bespokefit/executor/utilities/celery.py
@@ -36,11 +36,13 @@ def configure_celery_app(
     redis_host_name = redis_connection.connection_pool.connection_kwargs["host"]
     redis_port = redis_connection.connection_pool.connection_kwargs["port"]
     redis_db = redis_connection.connection_pool.connection_kwargs["db"]
+    username = redis_connection.connection_pool.connection_kwargs["username"]
+    password = redis_connection.connection_pool.connection_kwargs["password"]
 
     celery_app = Celery(
         app_name,
-        backend=f"redis://{redis_host_name}:{redis_port}/{redis_db}",
-        broker=f"redis://{redis_host_name}:{redis_port}/{redis_db}",
+        backend=f"redis://{username}:{password}@{redis_host_name}:{redis_port}/{redis_db}",
+        broker=f"redis://{username}:{password}@{redis_host_name}:{redis_port}/{redis_db}",
         include=include,
     )
 

--- a/openff/bespokefit/tests/cli/executor/test_launch.py
+++ b/openff/bespokefit/tests/cli/executor/test_launch.py
@@ -57,7 +57,6 @@ def test_launch(runner, monkeypatch):
             "--no-launch-redis",
         ],
     )
-    print(output.output)
     assert output.exit_code == 0
 
 

--- a/openff/bespokefit/tests/cli/test_worker.py
+++ b/openff/bespokefit/tests/cli/test_worker.py
@@ -1,0 +1,27 @@
+import pytest
+
+from openff.bespokefit.cli.worker import worker_cli
+from openff.bespokefit.executor.utilities import celery
+
+
+@pytest.mark.parametrize(
+    "worker_type",
+    [
+        pytest.param("fragmenter", id="fragmenter"),
+        pytest.param("qc-compute", id="qc-compute"),
+        pytest.param("optimizer", id="optimizer"),
+    ],
+)
+def test_launch_worker(worker_type, runner, monkeypatch):
+    """Test launching a worker of the correct type, note we do not start the worker this is tested
+    in test_celery/test_spawn_worker
+    """
+
+    def mock_spawn(*args):
+        return True
+
+    monkeypatch.setattr(celery, "_spawn_worker", mock_spawn)
+
+    output = runner.invoke(worker_cli, args=["--worker-type", worker_type])
+    assert output.exit_code == 0
+    assert worker_type in output.output

--- a/openff/bespokefit/tests/conftest.py
+++ b/openff/bespokefit/tests/conftest.py
@@ -58,6 +58,7 @@ from openff.bespokefit.schema.targets import (
     TorsionProfileTargetSchema,
     VibrationTargetSchema,
 )
+from openff.bespokefit.utilities import Settings, current_settings
 from openff.bespokefit.utilities.smirks import SMIRKSettings
 from openff.bespokefit.workflows.bespoke import BespokeWorkflowFactory
 
@@ -443,9 +444,12 @@ def redis_session(tmpdir_factory):
         "It looks like a redis server is already running with the test "
         "settings. Exiting early in-case this is a production redis server."
     )
+    settings = current_settings()
 
     try:
-        connection = redis.Redis(port=5678, db=0)
+        connection = redis.Redis(
+            port=5678, db=0, password=settings.BEFLOW_REDIS_PASSWORD
+        )
 
         keys = connection.keys("*")
         assert len(keys) == 0
@@ -468,7 +472,8 @@ def redis_session(tmpdir_factory):
 
 @pytest.fixture(scope="session")
 def redis_connection(redis_session) -> redis.Redis:
-    return redis.Redis(port=5678, db=0)
+    settings = current_settings()
+    return redis.Redis(port=5678, db=0, password=settings.BEFLOW_REDIS_PASSWORD)
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -477,3 +482,9 @@ def reset_redis(redis_connection, monkeypatch):
     redis_connection.set(
         "openff-bespokefit:redis-version", expected_redis_config_version()
     )
+
+
+@pytest.fixture(scope="session")
+def bespoke_settings() -> Settings:
+    settings = current_settings()
+    return settings

--- a/openff/bespokefit/tests/executor/services/optimizer/test_worker.py
+++ b/openff/bespokefit/tests/executor/services/optimizer/test_worker.py
@@ -3,6 +3,7 @@ import json
 from openff.fragmenter.fragment import WBOFragmenter
 from openff.toolkit.typing.engines.smirnoff import ForceField
 
+from openff.bespokefit.executor.services.coordinator.utils import _hash_fitting_schema
 from openff.bespokefit.executor.services.optimizer import worker
 from openff.bespokefit.optimizers import ForceBalanceOptimizer
 from openff.bespokefit.schema.fitting import (
@@ -17,7 +18,10 @@ from openff.bespokefit.schema.results import (
 from openff.bespokefit.schema.smirnoff import ProperTorsionSMIRKS
 
 
-def test_optimize(monkeypatch):
+def test_optimize(monkeypatch, redis_connection):
+    """
+    Mock an optimisation and make sure the parameter cache is updated with fitted parameters
+    """
     input_schema = BespokeOptimizationSchema(
         id="test",
         smiles="CC",
@@ -73,6 +77,16 @@ def test_optimize(monkeypatch):
     assert result.status == expected_output.status
 
     assert received_schema.json() == input_schema.stages[0].json()
+
+    # make sure the ff parameters were cached
+    task_hash = _hash_fitting_schema(fitting_schema=result.input_schema)
+    cached_ff_string = redis_connection.get(task_hash)
+    assert cached_ff_string is not None
+
+    # make sure our expected parameter has been cached
+    cached_ff = ForceField(cached_ff_string)
+    torsion_handler = cached_ff.get_parameter_handler("ProperTorsions")
+    assert "[*:1]-[#6X4:2]-[#6X4:3]-[*:4]" in torsion_handler.parameters
 
 
 def test_optimise_cache(bespoke_optimization_schema):

--- a/openff/bespokefit/tests/executor/utilities/test_redis.py
+++ b/openff/bespokefit/tests/executor/utilities/test_redis.py
@@ -11,15 +11,21 @@ from openff.bespokefit.executor.utilities.redis import (
 )
 
 
-def test_launch_redis(tmpdir):
-    assert not is_redis_available("localhost", 1234)
+def test_launch_redis(tmpdir, bespoke_settings):
+    assert not is_redis_available(
+        host="localhost", port=1234, password=bespoke_settings.BEFLOW_REDIS_PASSWORD
+    )
 
     redis_process = launch_redis(port=1234, directory=str(tmpdir), persistent=True)
 
     try:
-        assert is_redis_available("localhost", 1234)
+        assert is_redis_available(
+            host="localhost", port=1234, password=bespoke_settings.BEFLOW_REDIS_PASSWORD
+        )
 
-        redis_connection = Redis(port=1234)
+        redis_connection = Redis(
+            host="localhost", port=1234, password=bespoke_settings.BEFLOW_REDIS_PASSWORD
+        )
 
         assert (
             int(redis_connection.get("openff-bespokefit:redis-version"))
@@ -34,16 +40,22 @@ def test_launch_redis(tmpdir):
         redis_process.terminate()
         redis_process.wait()
 
-    assert not is_redis_available("localhost", 1234)
+    assert not is_redis_available(
+        host="localhost", port=1234, password=bespoke_settings.BEFLOW_REDIS_PASSWORD
+    )
 
     assert os.path.isfile(os.path.join(tmpdir, "redis.db"))
 
 
-def test_launch_redis_already_exists(tmpdir):
-    assert not is_redis_available("localhost", 1234)
+def test_launch_redis_already_exists(tmpdir, bespoke_settings):
+    assert not is_redis_available(
+        host="localhost", port=1234, password=bespoke_settings.BEFLOW_REDIS_PASSWORD
+    )
 
     redis_process = launch_redis(port=1234, directory=str(tmpdir), persistent=True)
-    assert is_redis_available("localhost", 1234)
+    assert is_redis_available(
+        host="localhost", port=1234, password=bespoke_settings.BEFLOW_REDIS_PASSWORD
+    )
 
     with pytest.raises(RuntimeError, match="here is already a server running"):
         launch_redis(port=1234, directory=str(tmpdir))
@@ -51,7 +63,9 @@ def test_launch_redis_already_exists(tmpdir):
     redis_process.terminate()
     redis_process.wait()
 
-    assert not is_redis_available("localhost", 1234)
+    assert not is_redis_available(
+        host="localhost", port=1234, password=bespoke_settings.BEFLOW_REDIS_PASSWORD
+    )
 
 
 @pytest.mark.parametrize("missing_command", ["redis-server", "redis-cli"])

--- a/openff/bespokefit/utilities/_settings.py
+++ b/openff/bespokefit/utilities/_settings.py
@@ -28,6 +28,7 @@ class Settings(BaseSettings):
     BEFLOW_REDIS_ADDRESS: str = "localhost"
     BEFLOW_REDIS_PORT: int = 6363
     BEFLOW_REDIS_DB: int = 0
+    BEFLOW_REDIS_PASSWORD: str = "bespokefit-server-1"
 
     BEFLOW_COORDINATOR_PREFIX = "tasks"
     BEFLOW_COORDINATOR_ROUTER = (


### PR DESCRIPTION
## Description
This PR exposes a CLI command to launch a celery worker manually which will try and connect to a bespokefit server. This is useful when the server and workers are not on the same machine. To allow for connections between redis and a celery worker on different machines a password is required which can be configured via the new setting `BEFLOW_REDIS_PASSWORD`.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] update the documentation with a guide to setting up remote workers

## Questions
- [ ] Question1

## Status
- [ ] Ready to go