### PR TITLE
Parallel torsiondrive optimisations

### DIFF
--- a/openff/bespokefit/cli/worker.py
+++ b/openff/bespokefit/cli/worker.py
@@ -45,10 +45,13 @@ def worker_cli(worker_type: str):
 
     settings = current_settings()
 
+    worker_kwargs = {}
+
     if worker_type == "fragmenter":
         worker_settings = settings.fragmenter_settings
     elif worker_type == "qc-compute":
         worker_settings = settings.qc_compute_settings
+        worker_kwargs["pool"] = "solo"
     else:
         worker_settings = settings.optimizer_settings
 
@@ -59,4 +62,4 @@ def worker_cli(worker_type: str):
     worker_status.stop()
     console.print(f"[[green]✓[/green]] bespoke {worker_type} worker launched")
 
-    spawn_worker(worker_app, concurrency=1, asynchronous=False)
+    spawn_worker(worker_app, concurrency=1, asynchronous=False, **worker_kwargs)

--- a/openff/bespokefit/executor/services/qcgenerator/qcengine.py
+++ b/openff/bespokefit/executor/services/qcgenerator/qcengine.py
@@ -1,6 +1,8 @@
-from multiprocessing import Pool
+import logging
+from multiprocessing import Pool, current_process
 from typing import Dict, List, Union
 
+from celery.utils.log import get_task_logger
 from qcelemental.models import FailedOperation
 from qcelemental.models.procedures import OptimizationResult, TorsionDriveInput
 from qcengine.config import TaskConfig
@@ -8,6 +10,8 @@ from qcengine.procedures import register_procedure
 from qcengine.procedures.torsiondrive import TorsionDriveProcedure
 
 from openff.bespokefit.executor.services import current_settings
+
+_task_logger: logging.Logger = get_task_logger(__name__)
 
 
 def _divide_config(config: TaskConfig, n_workers: int) -> TaskConfig:
@@ -43,6 +47,12 @@ class TorsionDriveProcedureParallel(TorsionDriveProcedure):
         settings = current_settings()
         program = input_model.optimization_spec.keywords["program"]
         opts_per_worker = settings.BEFLOW_QC_COMPUTE_WORKER_N_TASKS
+        # we can only split the tasks if the celery worker is the main process so if not set back to 1
+        if not current_process().name == "MainProcess":
+            _task_logger.info(
+                "Worker not in main process limited to serial optimisations."
+            )
+            opts_per_worker = 1
         if program == "psi4" and opts_per_worker == "auto":
             # we recommend 8 cores per worker for psi4 from our qcfractal jobs
             opts_per_worker = max([int(config.ncores / 8), 1])
@@ -55,6 +65,9 @@ class TorsionDriveProcedureParallel(TorsionDriveProcedure):
             # split the resources based on the number of tasks
             n_workers = int(min([n_jobs, opts_per_worker]))
             opt_config = _divide_config(config=config, n_workers=n_workers)
+            _task_logger.info(
+                f"Starting {n_workers} parallel optimisations for {n_jobs} jobs"
+            )
             with Pool(processes=n_workers) as pool:
                 tasks = {
                     grid_point: [

--- a/openff/bespokefit/executor/services/qcgenerator/qcengine.py
+++ b/openff/bespokefit/executor/services/qcgenerator/qcengine.py
@@ -60,7 +60,7 @@ class TorsionDriveProcedureParallel(TorsionDriveProcedure):
             n_workers = int(min([n_jobs, opts_per_worker]))
             opt_config = _divide_config(config=config, n_workers=n_workers)
 
-            # Using fork can hangs on our local HPC so pin to use spawn
+            # Using fork can hang on our local HPC so pin to use spawn
             with get_context("spwan").Pool(processes=n_workers) as pool:
                 tasks = {
                     grid_point: [

--- a/openff/bespokefit/executor/services/qcgenerator/qcengine.py
+++ b/openff/bespokefit/executor/services/qcgenerator/qcengine.py
@@ -1,8 +1,6 @@
-import logging
 from multiprocessing import Pool, current_process
 from typing import Dict, List, Union
 
-from celery.utils.log import get_task_logger
 from qcelemental.models import FailedOperation
 from qcelemental.models.procedures import OptimizationResult, TorsionDriveInput
 from qcengine.config import TaskConfig
@@ -10,8 +8,6 @@ from qcengine.procedures import register_procedure
 from qcengine.procedures.torsiondrive import TorsionDriveProcedure
 
 from openff.bespokefit.executor.services import current_settings
-
-_task_logger: logging.Logger = get_task_logger(__name__)
 
 
 def _divide_config(config: TaskConfig, n_workers: int) -> TaskConfig:
@@ -48,11 +44,9 @@ class TorsionDriveProcedureParallel(TorsionDriveProcedure):
         program = input_model.optimization_spec.keywords["program"]
         opts_per_worker = settings.BEFLOW_QC_COMPUTE_WORKER_N_TASKS
         # we can only split the tasks if the celery worker is the main process so if not set back to 1
-        if not current_process().name == "MainProcess":
-            _task_logger.info(
-                "Worker not in main process limited to serial optimisations."
-            )
+        if current_process().name != "MainProcess":
             opts_per_worker = 1
+
         if program == "psi4" and opts_per_worker == "auto":
             # we recommend 8 cores per worker for psi4 from our qcfractal jobs
             opts_per_worker = max([int(config.ncores / 8), 1])
@@ -65,9 +59,7 @@ class TorsionDriveProcedureParallel(TorsionDriveProcedure):
             # split the resources based on the number of tasks
             n_workers = int(min([n_jobs, opts_per_worker]))
             opt_config = _divide_config(config=config, n_workers=n_workers)
-            _task_logger.info(
-                f"Starting {n_workers} parallel optimisations for {n_jobs} jobs"
-            )
+
             with Pool(processes=n_workers) as pool:
                 tasks = {
                     grid_point: [

--- a/openff/bespokefit/executor/services/qcgenerator/qcengine.py
+++ b/openff/bespokefit/executor/services/qcgenerator/qcengine.py
@@ -61,7 +61,7 @@ class TorsionDriveProcedureParallel(TorsionDriveProcedure):
             opt_config = _divide_config(config=config, n_workers=n_workers)
 
             # Using fork can hang on our local HPC so pin to use spawn
-            with get_context("spwan").Pool(processes=n_workers) as pool:
+            with get_context("spawn").Pool(processes=n_workers) as pool:
                 tasks = {
                     grid_point: [
                         pool.apply_async(

--- a/openff/bespokefit/executor/services/qcgenerator/worker.py
+++ b/openff/bespokefit/executor/services/qcgenerator/worker.py
@@ -147,11 +147,18 @@ def compute_torsion_drive(task_json: str) -> TorsionDriveResult:
         ),
     )
 
+    # run all torsiondrives through our custom procedure which handles parallel optimisations
     return_value = qcengine.compute_procedure(
-        input_schema, "torsiondrive", raise_error=True, local_options=_task_config()
+        input_schema,
+        "TorsionDriveParallel",
+        raise_error=True,
+        task_config=_task_config(),
     )
 
     if isinstance(return_value, TorsionDriveResult):
+        _task_logger.info(
+            f"1D TorsionDrive successfully completed in {return_value.provenance.wall_time}"
+        )
         return_value = TorsionDriveResult(
             **return_value.dict(exclude={"optimization_history", "stdout", "stderr"}),
             optimization_history={},
@@ -204,7 +211,7 @@ def compute_optimization(
             input_schema,
             task.optimization_spec.program,
             raise_error=True,
-            local_options=_task_config(),
+            task_config=_task_config(),
         )
 
         if isinstance(return_value, OptimizationResult):

--- a/openff/bespokefit/executor/utilities/celery.py
+++ b/openff/bespokefit/executor/utilities/celery.py
@@ -55,19 +55,20 @@ def configure_celery_app(
     return celery_app
 
 
-def _spawn_worker(celery_app, concurrency: int = 1):
+def _spawn_worker(celery_app, concurrency: int = 1, **kwargs):
     worker = celery_app.Worker(
         concurrency=concurrency,
         loglevel="INFO",
         logfile=f"celery-{celery_app.main}.log",
         quiet=True,
         hostname=celery_app.main,
+        **kwargs,
     )
     worker.start()
 
 
 def spawn_worker(
-    celery_app, concurrency: int = 1, asynchronous: bool = True
+    celery_app, concurrency: int = 1, asynchronous: bool = True, **kwargs
 ) -> Optional[multiprocessing.Process]:
     if concurrency < 1:
         return
@@ -81,7 +82,7 @@ def spawn_worker(
         return worker_process
 
     else:
-        _spawn_worker(celery_app, concurrency)
+        _spawn_worker(celery_app, concurrency, **kwargs)
 
 
 def get_task_information(app: Celery, task_id: str) -> TaskInformation:

--- a/openff/bespokefit/tests/cli/test_worker.py
+++ b/openff/bespokefit/tests/cli/test_worker.py
@@ -17,7 +17,7 @@ def test_launch_worker(worker_type, runner, monkeypatch):
     in test_celery/test_spawn_worker
     """
 
-    def mock_spawn(*args):
+    def mock_spawn(*args, **kwargs):
         return True
 
     monkeypatch.setattr(celery, "_spawn_worker", mock_spawn)


### PR DESCRIPTION
## Description
This PR is another go at adding parallel optimisations in torsiondrives. These will only work on workers launched via the new worker CLI #272  option as they have to be in the primary process to spawn a pool of optimisations. 

Local testing with XTB and Psi4 for some simple molecules leads to some good speed-ups with the optimum number of workers being around 4. Note that for the Psi4 test, the number of threads used by each worker was 6 with 4 works and was 8 for 1 and 2 worker tests due to resource limits. 
![image](https://github.com/openforcefield/openff-bespokefit/assets/30259414/e2cb21d5-4dff-4671-af4b-38ccd22e3682)
![image](https://github.com/openforcefield/openff-bespokefit/assets/30259414/300df1d7-e8dc-4d5c-b176-1b6fba601b2b)

When testing on the HPC I found that the method to create the pool had to be set to `spawn` rather than `fork` otherwise the optimisations would hang, which causes a slight slowdown in performance should we expose the method used to create the pool as a setting? 

Testing script
```python
'''Run torsiondrives using the bespokefit parallel opt interface to compare the timings of the total job with the number of workers'''

from qcelemental.models.common_models import Model
from qcelemental.models.procedures import TorsionDriveInput, TDKeywords, QCInputSpecification, OptimizationSpecification
import qcengine
import os


from qcelemental.models import Molecule
from qcelemental.models.procedures import TorsionDriveInput
# make sure we can use the harness
from openff.bespokefit.executor.services.qcgenerator.qcengine import TorsionDriveProcedureParallel

test_mols = ['biphenyl.json', 'biaryl1.json', 'biaryl2.json']

def main():
    NCORES = 2
    MEMORY = 100
    N_P_TASKS = 2
    folder_name = f'xtb_{N_P_TASKS}_worker_{NCORES}_cores_spawn'
    os.makedirs(folder_name, exist_ok=True)


    os.environ['BEFLOW_QC_COMPUTE_WORKER_N_TASKS'] = str(N_P_TASKS)

    # general models used for each torsiondrive
    xtb_model = Model(method='gfn2xtb', basis=None)
    #psi4_model = Model(method='B3LYP-D3BJ', basis='DZVP')
    qc_spec = QCInputSpecification(
        driver='gradient',
        keywords={'verbosity': 'muted'},
        model=xtb_model
    )
    opt_spec = OptimizationSpecification(
        procedure='geometric',
        keywords={
            'coordsys': 'dlc',
            'enforce': 0.1,
            'reset': True,
            'qccnv': True,
            'epsilon': 0.0,
            'program': 'xtb'
        }

    )


    for fname in test_mols:

        print(f'Creating task for {fname}')
        mol: Molecule = Molecule.parse_file(fname)
        # get the  index of the rotatble bond
        # make the input
        td_keywords = TDKeywords(dihedrals=mol.extras['dihedrals'], grid_spacing=[15])

        task = TorsionDriveInput(
            keywords=td_keywords,
            input_specification=qc_spec,
            initial_molecule=[mol],
            optimization_spec=opt_spec
        )
        print('Done, Running TorsionDrive')
        result = qcengine.compute_procedure(input_data=task, procedure='TorsionDriveParallel', task_config={'ncores': NCORES, 'memory': MEMORY, 'retries': 2})

        print('Done saving result')
        file_name = fname.split('.')[0]
        with open(os.path.join(folder_name, file_name + '.json'), 'w') as output:
            output.write(result.json())


if __name__ == '__main__':
    main()
```

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] should we expose the pool creation method as a setting?

## Status
- [ ] Ready to go