### PR TITLE
Retry failed QM single points

### DIFF
--- a/openff/bespokefit/executor/services/qcgenerator/worker.py
+++ b/openff/bespokefit/executor/services/qcgenerator/worker.py
@@ -48,7 +48,7 @@ def _task_config() -> Dict[str, Any]:
         )
     )
 
-    return dict(ncores=n_cores, nnodes=1, memory=round(max_memory, 3))
+    return dict(ncores=n_cores, nnodes=1, memory=round(max_memory, 3), retries=3)
 
 
 def _select_atom(atoms: List[Atom]) -> int:


### PR DESCRIPTION
## Description
This PR sets the QC task config to include 3 retries on failed QM single points which should improve the robustness of torsiondrives and optimizations with Psi4. Its recommended that https://github.com/MolSSI/QCEngine/pull/409 be used as well to ensure random failures are restarted. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go