### PR TITLE
Update installation docs

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -47,7 +47,7 @@ mamba install -c openeye openeye-toolkits
 recommended to be installed unless you intend to train against data generated using a surrogate such as ANI:
 
 ```shell
-mamba install -c psi4 -c conda-forge -c defaults psi4
+mamba install -c conda-forge/label/libint_dev -c conda-forge psi4
 ```
 
 [Psi4]: https://psicode.org/
@@ -62,14 +62,15 @@ compiled dependencies found in multiple channels. An alternative is to install e
 initially creating the environment using, with AmberTools:
 
 ```shell
-mamba create -n bespokefit-env -c psi4 -c conda-forge -c defaults python=3.9 openff-bespokefit psi4 ambertools
+mamba create -n bespokefit-env -c conda-forge/label/libint_dev -c conda-forge python=3.10 openff-bespokefit psi4 ambertools
 ```
 
 or with OpenEye Toolkits:
 
 ```shell
-mamba create -n bespokefit-env -c psi4 -c conda-forge -c defaults -c openeye python=3.9 openff-bespokefit psi4 openeye-toolkits
+mamba create -n bespokefit-env -c conda-forge-label/libint_dev -c conda-forge -c openeye python=3.10 openff-bespokefit psi4 openeye-toolkits
 ```
+
 :::
 
 #### XTB
@@ -126,6 +127,7 @@ Create a custom conda environment which contains the required dependencies and a
 mamba env create --name openff-bespokefit --file devtools/conda-envs/test-env.yaml
 mamba activate openff-bespokefit
 ```
+
 Finally, install the package itself into the new environment:
 
 ```shell

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -16,6 +16,10 @@ mamba install -c conda-forge openff-bespokefit "qcportal <0.50"
 
 If you do not have Mamba installed, see the [OpenFF installation documentation](openff.docs:install).
 
+:::{warning}
+
+Some upstream dependencies may not be supported on Apple Silicon. To force `mamba` to use the use of the Rosetta emulation layer, use `CONDA_SUBDIR=osx-64`, which is described in more detail [here](https://docs.openforcefield.org/en/latest/install.html#openff-on-apple-silicon-and-arm).
+
 ### Fragmentation Backends
 
 #### AmberTools Antechamber

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -11,7 +11,7 @@ the two sections below ("Fragmentation Backends" and "Reference Data
 Generators")
 
 ```shell
-mamba install -c conda-forge openff-bespokefit
+mamba install -c conda-forge openff-bespokefit "qcportal <0.50"
 ```
 
 If you do not have Mamba installed, see the [OpenFF installation documentation](openff.docs:install).
@@ -62,13 +62,13 @@ compiled dependencies found in multiple channels. An alternative is to install e
 initially creating the environment using, with AmberTools:
 
 ```shell
-mamba create -n bespokefit-env -c conda-forge/label/libint_dev -c conda-forge python=3.10 openff-bespokefit psi4 ambertools
+mamba create -n bespokefit-env -c conda-forge/label/libint_dev -c conda-forge python=3.10 openff-bespokefit "qcportal <0.50" psi4 ambertools
 ```
 
 or with OpenEye Toolkits:
 
 ```shell
-mamba create -n bespokefit-env -c conda-forge-label/libint_dev -c conda-forge -c openeye python=3.10 openff-bespokefit psi4 openeye-toolkits
+mamba create -n bespokefit-env -c conda-forge-label/libint_dev -c conda-forge -c openeye python=3.10 openff-bespokefit "qcportal <0.50" psi4 openeye-toolkits
 ```
 
 :::
@@ -131,5 +131,5 @@ mamba activate openff-bespokefit
 Finally, install the package itself into the new environment:
 
 ```shell
-python setup.py develop
+python -m pip install -e .
 ```


### PR DESCRIPTION
## Checklist
- [x] Bump Python version to 3.10
- [x] Force `qcportal <0.50`
- [x] Remove references to `-c psi4`
- [x] Remove references to `-c defaults`
- [x] Use [blessed](https://psicode.org/installs/v182/) Psi4 installation pathway, which currently uses `-c conda-forge/label/libint_dev`
- [x] Update call to `python setup.py`

## Status
- [ ] Ready to go