### PR TITLE
Fix #319

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -9,6 +9,9 @@ Releases follow the ``major.minor.micro`` scheme recommended by
 
 <!-- ## Since last release -->
 
+### Bug fixes
+* [#320] - Fixes a formatting issue ([#319]) when printing SMILES to summary table. by [@j-wags]
+
 ## 0.2.3 / 14-11-2023
 
 ### Bug Fixes

--- a/openff/bespokefit/cli/executor/submit.py
+++ b/openff/bespokefit/cli/executor/submit.py
@@ -285,7 +285,12 @@ def _submit(
     for molecule, response_id in zip(all_molecules, response_ids):
         table.add_row(
             response_id,
-            molecule.to_smiles(explicit_hydrogens=False, mapped=False),
+            # Brackets around things like [nH] will sometimes be interpreted as formatting characters
+            # by rich, so use rich.markup.escape to avoid mangling the SMILES.
+            # See https://github.com/openforcefield/openff-bespokefit/issues/319
+            rich.markup.escape(
+                molecule.to_smiles(explicit_hydrogens=False, mapped=False)
+            ),
             molecule.name,
             molecule.properties.get("input_file", ""),
         )


### PR DESCRIPTION
## Description
#319 - SMILES can be mangled when the `rich` package interprets things like `[nH]` as formatting keywords.

I'm unable to make a test for this. Given the low severity, I'd propose that it go ahead with final review if nobody else can figure out a good testing strategy. 

## Todos
  - [x] Fix #319 
  - [ ] ~Add tests~ I couldn't figure out a reasonably quick way to test this. 
      - Running it with `workflow=debug` leads to a different table being output (one without SMILES)
      - I thought to copy a pattern from other things in `tests/cli`, but those didn't seem to output tables with SMILES.

## Status
- [x] Ready to go