### PR TITLE
Cache update docs

### DIFF
--- a/docs/users/bespoke-executor.md
+++ b/docs/users/bespoke-executor.md
@@ -111,6 +111,28 @@ corresponding environment variable [settings] are used instead.
 [QCEngine]: http://docs.qcarchive.molssi.org/projects/QCEngine/en/stable/
 [settings]: openff.bespokefit.utilities.Settings
 
+(executor_qc_cache)=
+## The QC cache
+Bespokefit makes extensive use of caching to speed up the parameterization process. 
+The generation of the training data is currently the slowest part of the workflow when running DFT calculations with 
+a high level of theory. To further speed up the process we provide an interface to seed the cache with results from 
+[QCArchive] which contains hundreds of torsiondrives. The `cache` command allows you to select a dataset and translate 
+it into local copies of the records which means your molecule data is not shared with QCArchive as the look up is done locally.
+
+First you should start a Bespoke [executor](executor_using_cli) and specify the location of the working directory which will store the cache
+
+```shell
+openff-bespoke executor launch --directory bespoke
+```
+
+While this is running from another terminal run the cache update using any of the available datasets
+
+```shell
+openff-bespoke cache update --qcf-dataset "OpenFF-benchmark-ligand-fragments-v2.0" --qcf-address "https://api.qcarchive.molssi.org:443/"
+```
+
+[QCArchive]: https://qcarchive.molssi.org/
+
 (executor_using_api)=
 ## Using the API
 


### PR DESCRIPTION
## Description
This PR adds instructions on how to update the calculation cache with datasets in QCArchive.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] Have someone test out the docs

## Questions
- [ ] Should we provide a function to grab all relevant datasets automatically from QCArchive? Do we want to have to keep this up to date? 

## Status
- [ ] Ready to go