### PR TITLE
Set up  API token in uploading coverage reports

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -74,6 +74,7 @@ jobs:
       - name: Codecov
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
           fail_ci_if_error: false
 


### PR DESCRIPTION
I added `CODECOV_TOKEN` from https://app.codecov.io/gh/openforcefield/openff-bespokefit/settings to https://github.com/openforcefield/openff-bespokefit/settings/secrets/actions, following what we've done in other projects