### PR TITLE
Bump tests to Python 3.10

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        python-version: [3.9]
+        python-version: ["3.10"]
         openeye: [true, false]
         integration: [true]
 


### PR DESCRIPTION
April 05, 2024 is not so far away https://numpy.org/neps/nep-0029-deprecation_policy.html