### PR TITLE
Repair documentation of environment variables

### DIFF
--- a/docs/getting-started/bespoke-cli.md
+++ b/docs/getting-started/bespoke-cli.md
@@ -11,6 +11,8 @@ openff-bespoke --help
 openff-bespoke executor launch --help
 ```
 
+The executor can also be configured via [environment variables.](envvars)
+
 See the [quick start](quick_start_chapter) guide for examples of using the CLI.
 
 (cli_ref)=

--- a/docs/users/bespoke-executor.md
+++ b/docs/users/bespoke-executor.md
@@ -182,7 +182,10 @@ Both the CLI and the Python API can be configured via environment variables.
     :field-signature-prefix: env
     :noindex:
 
-    The following environment variables may be used to configure the Bespoke Executor
+    The following environment variables may be used to configure the Bespoke Executor. Environment variables are typically set in the shell:
+
+    .. code-block:: shell-session
+
+        $ BEFLOW_KEEP_TMP_FILES=True openff-bespoke executor ...
 
 :::
-

--- a/docs/users/bespoke-executor.md
+++ b/docs/users/bespoke-executor.md
@@ -164,12 +164,13 @@ a result.
 [`BespokeExecutor`]: openff.bespokefit.executor.BespokeExecutor
 [`BespokeWorkerConfig`]: openff.bespokefit.executor.BespokeWorkerConfig
 
+(envvars)=
 ## Configuring from the environment
 
 Both the CLI and the Python API can be configured via environment variables.
 
 :::{eval-rst}
-.. autopydantic_settings:: openff.bespokefit.executor.services._settings.Settings
+.. autopydantic_settings:: openff.bespokefit.executor.services.Settings
     :settings-show-json: False
     :settings-show-config-member: False
     :settings-show-config-summary: False
@@ -179,6 +180,7 @@ Both the CLI and the Python API can be configured via environment variables.
     :exclude-members: fragmenter_settings,qc_compute_settings,optimizer_settings,apply_env
     :settings-signature-prefix: Environment Variables
     :field-signature-prefix: env
+    :noindex:
 
     The following environment variables may be used to configure the Bespoke Executor
 

--- a/openff/bespokefit/utilities/_settings.py
+++ b/openff/bespokefit/utilities/_settings.py
@@ -71,7 +71,14 @@ class Settings(BaseSettings):
     """
 
     BEFLOW_KEEP_TMP_FILES: bool = False
-    """Keep all temporary files."""
+    """
+    Keep all temporary files.
+
+    Temporary files are written to the scratch directory, which can be
+    configured with the ``--directory`` CLI argument. By default, a temporary
+    directory is chosen for scratch, so both this environment variable and that
+    CLI argument must be set to preserve temporary files.
+    """
 
     @property
     def fragmenter_settings(self) -> WorkerSettings:

--- a/openff/bespokefit/utilities/_settings.py
+++ b/openff/bespokefit/utilities/_settings.py
@@ -65,7 +65,7 @@ class Settings(BaseSettings):
     BEFLOW_OPTIMIZER_KEEP_FILES: bool = False
     """
     .. deprecated:: 0.2.1
-        use BEFLOW_KEEP_TMP_FILES instead
+        use ``BEFLOW_KEEP_TMP_FILES`` instead
 
     Keep the optimizer's temporary files.
     """


### PR DESCRIPTION
## Description
This fixes the documentation of environment variables to control bespoke executor.

Closes #326

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Fix automatic documentation of environment variables
  - [x] Add a link to the env vars section to the CLI page

## Status
- [x] Ready to go