### PR TITLE
Add Docker support to easily launch the server 

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,6 @@
+# The port the executor can be reached on
+BEFLOW_GATEWAY_PORT=
+# The password to the redis database only workers and the executor need this
+BEFLOW_REDIS_PASSWORD=
+# If ForceBalance tmp files should be kept?
+BEFLOW_KEEP_TMP_FILES=

--- a/.env.template
+++ b/.env.template
@@ -4,3 +4,5 @@ BEFLOW_GATEWAY_PORT=
 BEFLOW_REDIS_PASSWORD=
 # If ForceBalance tmp files should be kept?
 BEFLOW_KEEP_TMP_FILES=
+# bind to the local host to ensure the executor can reach redis
+BEFLOW_REDIS_ADDRESS="0.0.0.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ENV PYTHONUNBUFFERED=1
 
 COPY --chown=$MAMBA_USER:$MAMBA_USER devtools/conda-envs/bespokefit-server.yaml /tmp/env.yaml
 COPY --chown=$MAMBA_USER:$MAMBA_USER openff /tmp/openff
+COPY --chown=$MAMBA_USER:$MAMBA_USER LICENSE README.md setup.cfg setup.py /tmp/
 RUN micromamba install -y -n base git -f /tmp/env.yaml && \
     micromamba clean --all --yes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM mambaorg/micromamba:1.5.8
+
+LABEL org.opencontainers.image.source=https://github.com/openforcefield/openff-bespokefit
+LABEL org.opencontainers.image.description="Automated tools for the generation of bespoke SMIRNOFF format parameters for individual molecules."
+LABEL org.opencontainers.image.licenses=MIT
+
+# Don't buffer stdout & stderr streams, so if there is a crash no partial buffer output is lost
+# https://docs.python.org/3/using/cmdline.html#cmdoption-u
+ENV PYTHONUNBUFFERED=1
+
+COPY --chown=$MAMBA_USER:$MAMBA_USER devtools/conda-envs/bespokefit-server.yaml /tmp/env.yaml
+COPY --chown=$MAMBA_USER:$MAMBA_USER openff /tmp/openff
+RUN micromamba install -y -n base git -f /tmp/env.yaml && \
+    micromamba clean --all --yes
+
+# Ensure that conda environment is automatically activated
+# https://github.com/mamba-org/micromamba-docker#running-commands-in-dockerfile-within-the-conda-environment
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+RUN python -m pip install --no-deps -e .
+
+WORKDIR /home/mambauser
+RUN mkdir /home/mambauser/.OpenEye
+ENV OE_LICENSE=/home/mambauser/.OpenEye/oe_license.txt

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+
+services:
+  falcbot:
+    command: openff-bespoke executor launch --launch-redis --n-optimizer-workers 0 --n-qc-compute-workers 0 --n-fragmenter-workers 0 --directory bespoke-executor
+    build: .
+    container_name: "bepokefit-server"
+    ports:
+      - 80:8000
+    volumes:
+      - type: bind
+        source: $HOME/.OpenEye/
+        target: /home/mambauser/.OpenEye/
+    env_file:
+      - .env

--- a/devtools/conda-envs/bespokefit-server.yaml
+++ b/devtools/conda-envs/bespokefit-server.yaml
@@ -1,0 +1,46 @@
+name: bespokefit-server
+
+channels:
+  - openeye
+  - conda-forge
+
+dependencies:
+
+    # Base depends
+  - python
+  - pip
+
+    ### Core dependencies.
+
+  - numpy
+  - pydantic
+  - pyyaml
+  - tqdm
+  - rich
+  - click
+  - click-option-group
+  - rdkit
+  - openff-utilities
+  - openff-toolkit-base =0.15
+  - openff-interchange  # only needed because openff-toolkit-base
+  - openff-units
+  - openff-qcsubmit >=0.50
+
+    # Optional
+  - openff-fragmenter-base
+  - openeye-toolkits
+
+    ### Bespoke dependencies
+
+  - qcportal ==0.53
+  - qcelemental
+  - chemper
+
+    # Executor
+  - uvicorn
+  - fastapi
+  - starlette
+  - celery
+  - httpx
+  - redis-server
+  - redis-py

--- a/devtools/conda-envs/bespokefit-server.yaml
+++ b/devtools/conda-envs/bespokefit-server.yaml
@@ -13,7 +13,7 @@ dependencies:
     ### Core dependencies.
 
   - numpy
-  - pydantic
+  - pydantic >=1.10.8,<2.0.0a0
   - pyyaml
   - tqdm
   - rich
@@ -22,9 +22,9 @@ dependencies:
   - rdkit
   - openff-utilities
   - openff-toolkit-base =0.15
-  - openff-interchange  # only needed because openff-toolkit-base
   - openff-units
-  - openff-qcsubmit >=0.50
+  - openff-qcsubmit
+  - versioneer
 
     # Optional
   - openff-fragmenter-base
@@ -32,10 +32,9 @@ dependencies:
 
     ### Bespoke dependencies
 
-  - qcportal ==0.53
   - qcelemental
   - chemper
-
+  - qcengine
     # Executor
   - uvicorn
   - fastapi


### PR DESCRIPTION
## Description
This PR adds a docker and docker compose file that makes it easier to launch just the bespokefit server on a remote machine. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] add files needed for docker
  - [ ] build the docker image as part of the CI?

## Questions
- [ ] Question1

## Status
- [ ] Ready to go