### PR TITLE
BespokeFit client

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -245,7 +245,12 @@ a charge model, then re-fit the torsion and valence parameters using the new cha
 Such a schema is fed into a [`BespokeExecutor`] that will run the full workflow:
 
 ```python
-from openff.bespokefit.executor import BespokeExecutor, BespokeWorkerConfig, wait_until_complete
+from openff.bespokefit.executor import BespokeExecutor, BespokeWorkerConfig
+from openff.bespokefit.executor.client import BespokeFitClient, Settings
+
+# create a client to interface with the executor
+settings = Settings()
+client = BespokeFitClient(settings=settings)
 
 with BespokeExecutor(
     n_fragmenter_workers = 1,
@@ -254,9 +259,9 @@ with BespokeExecutor(
     qc_compute_worker_config=BespokeWorkerConfig(n_cores=1)
 ) as executor:
     # Submit our workflow to the executor
-    task_id = executor.submit(input_schema=workflow_schema)
+    task_id = client.submit_optimization(input_schema=workflow_schema)
     # Wait until the executor is done
-    output = wait_until_complete(task_id)
+    output = client.wait_until_complete(task_id)
 
 if output.status == "success":
     # Save the resulting force field to an OFFXML file

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -11,6 +11,7 @@ Releases follow the ``major.minor.micro`` scheme recommended by
 
 ## Current development
 
+* [#351] - Adds a `BespokeFitClient` to interface with the executor and support for connecting to executors on a non-local machine [@jthorton]
 * [#338] - Updates a test for QCFractal/QCPortal 0.54. [@mattwthompson]
 
 ## 0.3.0 / 27-03-2024
@@ -160,6 +161,7 @@ The first major release of bespokefit intended for public use.
 [#330]: https://github.com/openforcefield/openff-bespokefit/pull/330
 [#334]: https://github.com/openforcefield/openff-bespokefit/pull/334
 [#338]: https://github.com/openforcefield/openff-bespokefit/pull/338
+[#351]: https://github.com/openforcefield/openff-bespokefit/pull/351
 
 
 [@Yoshanuikabundi]: https://github.com/Yoshanuikabundi

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -9,6 +9,10 @@ Releases follow the ``major.minor.micro`` scheme recommended by
 
 <!-- ## Since last release -->
 
+## Current development
+
+* [#338] - Updates a test for QCFractal/QCPortal 0.54. [@mattwthompson]
+
 ## 0.3.0 / 27-03-2024
 
 ### New Features
@@ -155,6 +159,7 @@ The first major release of bespokefit intended for public use.
 [#325]: https://github.com/openforcefield/openff-bespokefit/pull/325
 [#330]: https://github.com/openforcefield/openff-bespokefit/pull/330
 [#334]: https://github.com/openforcefield/openff-bespokefit/pull/334
+[#338]: https://github.com/openforcefield/openff-bespokefit/pull/338
 
 
 [@Yoshanuikabundi]: https://github.com/Yoshanuikabundi

--- a/docs/users/bespoke-executor.md
+++ b/docs/users/bespoke-executor.md
@@ -163,28 +163,31 @@ be allowed to use the full set of CPUs available on the machine (`n_cores="auto"
 The executor itself is a context manager and will not 'start' until the context is entered:
 
 ```python
-from openff.bespokefit.executor import wait_until_complete
+from openff.bespokefit.executor.client import BespokeFitClient, Settings
+
+client = BespokeFitClient(settings=Settings())
 
 with executor:
-    task_id = BespokeExecutor.submit(workflow)
-    output = wait_until_complete(task_id)
+    task_id = client.submit_optimization(input_schema=workflow)
+    output = client.wait_until_complete(optimization_id=task_id)
 ```
 
 When an executor 'starts' it will spin up all the required child processes, including each worker and a [Redis]
 instance (unless Redis is disabled).
 
-Within the executor context bespoke fits can be submitted using the [`submit()`] method. As soon as the context manager
-exists the executor instance is closed, terminating any running jobs. To ensure the submission is allowed to finish,
-use the [`wait_until_complete()`] helper function. This function will block progress in the script until it can return
-a result.
+Within the executor context bespoke fits can be submitted using the [`BespokeFitClient`] via the  [`submit_optimization()`] method. 
+As soon as the context manager exists the executor instance is closed, terminating any running jobs. 
+To ensure the submission is allowed to finish, use the [`wait_until_complete()`] helper function of the client. 
+This function will block progress in the script until it can return a result.
 
 [Celery]: https://docs.celeryproject.org/en/stable/index.html
 [Redis]: https://redis.io/
 
-[`submit()`]: openff.bespokefit.executor.BespokeExecutor.submit
-[`wait_until_complete()`]: openff.bespokefit.executor.wait_until_complete
+[`submit_optimization()`]: openff.bespokefit.executor.client.BespokeFitClient.submit_optimization
+[`wait_until_complete()`]: openff.bespokefit.executor.client.BespokeFitClient.wait_until_complete
 [`BespokeExecutor`]: openff.bespokefit.executor.BespokeExecutor
 [`BespokeWorkerConfig`]: openff.bespokefit.executor.BespokeWorkerConfig
+[`BespokeFitClient`]: openff.bespokefit.executor.client.BespokeFitClient
 
 (envvars)=
 ## Configuring from the environment

--- a/docs/users/bespoke-results.md
+++ b/docs/users/bespoke-results.md
@@ -17,8 +17,12 @@ A force field file will only be saved if the fit has successfully finished.
 Or using the Python API:
 
 ```python
-from openff.bespokefit.executor import BespokeExecutor
-output = BespokeExecutor.retrieve(optimization_id="1")
+from openff.bespokefit.executor.client import BespokeFitClient, Settings
+
+settings = Settings()
+client = BespokeFitClient(settings=settings)
+
+output = client.get_optimization(optimization_id="1")
 ```
 
 In both cases the output will be stored in a [`BespokeExecutorOutput`] class. When using the command 

--- a/openff/bespokefit/_tests/cli/executor/test_list.py
+++ b/openff/bespokefit/_tests/cli/executor/test_list.py
@@ -1,40 +1,13 @@
 import pytest
 import requests_mock
-import rich
 
-from openff.bespokefit.cli.executor.list import _get_columns, list_cli
+from openff.bespokefit.cli.executor.list import list_cli
 from openff.bespokefit.executor.services import current_settings
 from openff.bespokefit.executor.services.coordinator.models import (
     CoordinatorGETPageResponse,
     CoordinatorGETResponse,
 )
 from openff.bespokefit.executor.services.models import Link
-
-
-def test_get_columns():
-    settings = current_settings()
-
-    with requests_mock.Mocker() as m:
-        mock_response = CoordinatorGETResponse(
-            self="self-page",
-            id="1",
-            smiles="[C:1]([H:2])([H:3])=[C:4]([H:5])[H:6]",
-            stages=[],
-        )
-
-        m.get(
-            (
-                f"http://127.0.0.1:"
-                f"{settings.BEFLOW_GATEWAY_PORT}"
-                f"{settings.BEFLOW_API_V1_STR}/"
-                f"{settings.BEFLOW_COORDINATOR_PREFIX}/1"
-            ),
-            text=mock_response.json(by_alias=True),
-        )
-
-        smiles, status = _get_columns(rich.get_console(), "1")
-        assert smiles == "C=C"
-        assert status == "success"
 
 
 @pytest.mark.parametrize(

--- a/openff/bespokefit/_tests/cli/test_cache.py
+++ b/openff/bespokefit/_tests/cli/test_cache.py
@@ -153,8 +153,11 @@ def test_update_from_qcsubmit(redis_connection):
     assert redis_connection.hget("qcgenerator:types", task_id) == b"torsion1d"
 
 
-def test_cache_cli_fractal(runner, tmpdir):
+def test_cache_cli_fractal(runner, tmpdir, redis_session, monkeypatch):
     """Test running the cache update cli."""
+
+    # point the CLI to the same redis testing DB
+    monkeypatch.setenv("BEFLOW_REDIS_PORT", 5678)
 
     output = runner.invoke(
         update_cli,
@@ -163,6 +166,7 @@ def test_cache_cli_fractal(runner, tmpdir):
             "OpenFF Gen 2 Torsion Set 6 supplemental 2",
             "--qcf-datatype",
             "torsion",
+            "--no-launch-redis",
         ],
     )
     assert output.exit_code == 0, print(output.output)

--- a/openff/bespokefit/_tests/cli/test_worker.py
+++ b/openff/bespokefit/_tests/cli/test_worker.py
@@ -17,10 +17,12 @@ def test_launch_worker(worker_type, runner, monkeypatch):
     in test_celery/test_spawn_worker
     """
 
-    def mock_spawn(*args, **kwargs):
-        return True
+    launched_workers = {}
 
-    monkeypatch.setattr(celery, "_spawn_worker", mock_spawn)
+    def mock_spawn_worker(app, concurrency, asynchronous, pool=None):
+        launched_workers[app.main] = concurrency
+
+    monkeypatch.setattr(celery, "spawn_worker", mock_spawn_worker)
 
     output = runner.invoke(worker_cli, args=["--worker-type", worker_type])
     assert output.exit_code == 0

--- a/openff/bespokefit/_tests/executor/test_client.py
+++ b/openff/bespokefit/_tests/executor/test_client.py
@@ -7,6 +7,14 @@ from openff.bespokefit.executor import BespokeExecutor, BespokeFitClient
 from openff.bespokefit.utilities._settings import Settings
 
 
+def test_token_warning():
+    settings = Settings(BEFLOW_API_TOKEN="test")
+    with pytest.warns(
+        match="Using an API token without an https connection is insecure, consider using https for encrypted comunication."
+    ):
+        _ = BespokeFitClient(settings=settings)
+
+
 def test_authentication(tmpdir):
     """Simple authentication test"""
     # set the API key before starting the server

--- a/openff/bespokefit/_tests/executor/test_client.py
+++ b/openff/bespokefit/_tests/executor/test_client.py
@@ -1,29 +1,30 @@
 import os
 
 import pytest
-from fastapi import HTTPException
+from requests import HTTPError
 
 from openff.bespokefit.executor import BespokeExecutor, BespokeFitClient
 from openff.bespokefit.utilities._settings import Settings
 
 
 def test_authentication(tmpdir):
-    settings = Settings()
-    print(settings)
+    """Simple authentication test"""
+    # set the API key before starting the server
+    settings = Settings(BEFLOW_API_TOKEN="secure-key")
     with settings.apply_env():
         executor = BespokeExecutor(
             n_fragmenter_workers=0,
             n_qc_compute_workers=0,
             n_optimizer_workers=0,
             directory=os.path.join(tmpdir, "mock-exe-dir"),
-            launch_redis_if_unavailable=False,
+            launch_redis_if_unavailable=True,
         )
         with executor:
             client = BespokeFitClient(settings=settings)
-            # make sure we can access the server
+            # make sure we can access the server using the correct key
             _ = client.list_optimizations()
             # now change the token and try again
             settings.BEFLOW_API_TOKEN = "wrong-token"
             client = BespokeFitClient(settings=settings)
-            with pytest.raises(HTTPException):
+            with pytest.raises(HTTPError):
                 _ = client.list_optimizations()

--- a/openff/bespokefit/_tests/executor/test_client.py
+++ b/openff/bespokefit/_tests/executor/test_client.py
@@ -28,3 +28,5 @@ def test_authentication(tmpdir):
             client = BespokeFitClient(settings=settings)
             with pytest.raises(HTTPError):
                 _ = client.list_optimizations()
+            # make sure to shut down the executor
+            executor._cleanup_processes()

--- a/openff/bespokefit/_tests/executor/test_client.py
+++ b/openff/bespokefit/_tests/executor/test_client.py
@@ -1,0 +1,29 @@
+import os
+
+import pytest
+from fastapi import HTTPException
+
+from openff.bespokefit.executor import BespokeExecutor, BespokeFitClient
+from openff.bespokefit.utilities._settings import Settings
+
+
+def test_authentication(tmpdir):
+    settings = Settings()
+    print(settings)
+    with settings.apply_env():
+        executor = BespokeExecutor(
+            n_fragmenter_workers=0,
+            n_qc_compute_workers=0,
+            n_optimizer_workers=0,
+            directory=os.path.join(tmpdir, "mock-exe-dir"),
+            launch_redis_if_unavailable=False,
+        )
+        with executor:
+            client = BespokeFitClient(settings=settings)
+            # make sure we can access the server
+            _ = client.list_optimizations()
+            # now change the token and try again
+            settings.BEFLOW_API_TOKEN = "wrong-token"
+            client = BespokeFitClient(settings=settings)
+            with pytest.raises(HTTPException):
+                _ = client.list_optimizations()

--- a/openff/bespokefit/_tests/executor/test_executor.py
+++ b/openff/bespokefit/_tests/executor/test_executor.py
@@ -10,7 +10,6 @@ from openff.bespokefit.executor import (
     BespokeExecutor,
     BespokeExecutorOutput,
     BespokeExecutorStageOutput,
-    wait_until_complete,
 )
 from openff.bespokefit.executor.services import current_settings
 from openff.bespokefit.executor.services.coordinator.models import (
@@ -411,9 +410,9 @@ def test_wait_for_stage(status):
     assert response.results is None
 
 
-def test_wait_until_complete():
-    with mock_get_response("success") as mock_response:
-        response = wait_until_complete(mock_response.id, frequency=0.1)
-
-    assert isinstance(response, BespokeExecutorOutput)
-    assert response.stages[0].status == "success"
+# def test_wait_until_complete():
+#     with mock_get_response("success") as mock_response:
+#         response = wait_until_complete(mock_response.id, frequency=0.1)
+#
+#     assert isinstance(response, BespokeExecutorOutput)
+#     assert response.stages[0].status == "success"

--- a/openff/bespokefit/_tests/executor/test_executor.py
+++ b/openff/bespokefit/_tests/executor/test_executor.py
@@ -10,6 +10,7 @@ from openff.bespokefit.executor import (
     BespokeExecutor,
     BespokeExecutorOutput,
     BespokeExecutorStageOutput,
+    BespokeFitClient,
 )
 from openff.bespokefit.executor.services import current_settings
 from openff.bespokefit.executor.services.coordinator.models import (
@@ -277,7 +278,7 @@ class TestBespokeExecutor:
 
     def test_submit(self, bespoke_optimization_schema):
         settings = current_settings()
-
+        client = BespokeFitClient(settings=settings)
         expected = CoordinatorPOSTResponse(id="mock-id", self="")
 
         with requests_mock.Mocker() as m:
@@ -291,12 +292,13 @@ class TestBespokeExecutor:
                 text=expected.json(),
             )
 
-            result_id = BespokeExecutor.submit(bespoke_optimization_schema)
+            result_id = client.submit_optimization(bespoke_optimization_schema)
             assert result_id == expected.id
 
     def test_retrieve(self, bespoke_optimization_schema):
         with mock_get_response():
-            output = BespokeExecutor.retrieve("mock-id")
+            client = BespokeFitClient(settings=current_settings())
+            output = client.get_optimization("mock-id")
             assert output.status == "running"
 
     def test_enter_exit(self, tmpdir):
@@ -325,7 +327,6 @@ class TestBespokeExecutor:
 
 
 def test_query_coordinator():
-    from openff.bespokefit.executor.executor import _query_coordinator
 
     mock_response = CoordinatorGETResponse(
         id="mock-id",
@@ -343,6 +344,7 @@ def test_query_coordinator():
         return mock_response.json(by_alias=True)
 
     settings = current_settings()
+    client = BespokeFitClient(settings=settings)
 
     mock_href = (
         f"http://127.0.0.1:"
@@ -354,14 +356,13 @@ def test_query_coordinator():
 
     with requests_mock.Mocker() as m:
         m.get(mock_href, text=mock_callback)
-        response = _query_coordinator(mock_href)
+        response = client._query_coordinator(mock_href)
 
     assert response.json() == mock_response.json()
 
 
 @pytest.mark.parametrize("status", ["success", "errored"])
 def test_wait_for_stage(status):
-    from openff.bespokefit.executor.executor import _wait_for_stage
 
     mock_response = CoordinatorGETResponse(
         id="mock-id",
@@ -388,6 +389,7 @@ def test_wait_for_stage(status):
         return response_json
 
     settings = current_settings()
+    client = BespokeFitClient(settings=settings)
 
     mock_href = (
         f"http://127.0.0.1:"
@@ -400,7 +402,9 @@ def test_wait_for_stage(status):
     with requests_mock.Mocker() as m:
         m.get(mock_href, text=mock_callback)
 
-        response = _wait_for_stage(mock_href, "fragmentation", frequency=0.01)
+        response = client._wait_for_stage(
+            mock_response.id, "fragmentation", frequency=0.01
+        )
 
     assert response is not None
     assert n_requests == 2

--- a/openff/bespokefit/_tests/executor/test_executor.py
+++ b/openff/bespokefit/_tests/executor/test_executor.py
@@ -414,9 +414,11 @@ def test_wait_for_stage(status):
     assert response.results is None
 
 
-# def test_wait_until_complete():
-#     with mock_get_response("success") as mock_response:
-#         response = wait_until_complete(mock_response.id, frequency=0.1)
-#
-#     assert isinstance(response, BespokeExecutorOutput)
-#     assert response.stages[0].status == "success"
+def test_wait_until_complete():
+    settings = current_settings()
+    client = BespokeFitClient(settings=settings)
+    with mock_get_response("success") as mock_response:
+        response = client.wait_until_complete(mock_response.id, frequency=0.1)
+
+    assert isinstance(response, BespokeExecutorOutput)
+    assert response.stages[0].status == "success"

--- a/openff/bespokefit/_tests/schema/test_targets.py
+++ b/openff/bespokefit/_tests/schema/test_targets.py
@@ -145,11 +145,8 @@ class TestCheckConnectivity:
             pass
 
         if isinstance(record, qcportal.torsiondrive.TorsiondriveRecord):
-            final_records = {
-                key: val for key, val in record.minimum_optimizations_cache_.items()
-            }
 
-            for _record in final_records.values():
+            for _record in record.minimum_optimizations.values():
                 pos0 = _record.final_molecule.geometry[0]
                 pos1 = _record.final_molecule.geometry[1]
                 _record.final_molecule.geometry[0] = pos1

--- a/openff/bespokefit/cli/combine.py
+++ b/openff/bespokefit/cli/combine.py
@@ -69,10 +69,13 @@ def combine_cli(
         )
 
     if task_ids:
-        from openff.bespokefit.executor import BespokeExecutor
+        from openff.bespokefit.executor import BespokeFitClient
+        from openff.bespokefit.executor.services import current_settings
+
+        client = BespokeFitClient(settings=current_settings())
 
         with handle_common_errors(console) as error_state:
-            results = [BespokeExecutor.retrieve(task_id) for task_id in task_ids]
+            results = [client.get_optimization(task_id) for task_id in task_ids]
         if error_state["has_errored"]:
             raise click.exceptions.Exit(code=2)
 

--- a/openff/bespokefit/cli/executor/retrieve.py
+++ b/openff/bespokefit/cli/executor/retrieve.py
@@ -1,11 +1,4 @@
 import click
-import click.exceptions
-import rich
-from rich import pretty
-from rich.padding import Padding
-
-from openff.bespokefit.cli.utilities import print_header
-from openff.bespokefit.executor.utilities import handle_common_errors
 
 
 @click.command("retrieve")
@@ -32,6 +25,13 @@ from openff.bespokefit.executor.utilities import handle_common_errors
 )
 def retrieve_cli(optimization_id, output_file_path, force_field_path):
     """Retrieve the current output of a bespoke optimization."""
+    import click.exceptions
+    import rich
+    from rich import pretty
+    from rich.padding import Padding
+
+    from openff.bespokefit.cli.utilities import print_header
+    from openff.bespokefit.executor.utilities import handle_common_errors
 
     pretty.install()
 
@@ -44,10 +44,14 @@ def retrieve_cli(optimization_id, output_file_path, force_field_path):
             "specified."
         )
 
-    from openff.bespokefit.executor import BespokeExecutor
+    from openff.bespokefit.executor import BespokeFitClient
+    from openff.bespokefit.executor.services import current_settings
+
+    settings = current_settings()
+    client = BespokeFitClient(settings=settings)
 
     with handle_common_errors(console) as error_state:
-        results = BespokeExecutor.retrieve(optimization_id)
+        results = client.get_optimization(optimization_id=optimization_id)
     if error_state["has_errored"]:
         raise click.exceptions.Exit(code=2)
 

--- a/openff/bespokefit/cli/executor/run.py
+++ b/openff/bespokefit/cli/executor/run.py
@@ -46,15 +46,18 @@ def _run_cli(
 
     from openff.bespokefit.executor import (
         BespokeExecutor,
+        BespokeFitClient,
         BespokeWorkerConfig,
-        wait_until_complete,
     )
+    from openff.bespokefit.executor.services import current_settings
     from openff.bespokefit.executor.utilities import handle_common_errors
 
     executor_status = console.status("launching the bespoke executor")
     executor_status.start()
 
     validate_redis_connection(console, allow_existing=False)
+    settings = current_settings()
+    client = BespokeFitClient(settings=settings)
 
     with BespokeExecutor(
         directory=directory,
@@ -91,7 +94,9 @@ def _run_cli(
 
             console.print(Padding("3. running the fitting pipeline", (1, 0, 1, 0)))
 
-            results = wait_until_complete(response_id[0])
+            results = client.wait_until_complete(
+                optimization_id=response_id[0], console=console
+            )
 
             console.print(
                 Padding(

--- a/openff/bespokefit/cli/executor/submit.py
+++ b/openff/bespokefit/cli/executor/submit.py
@@ -200,7 +200,11 @@ def _submit(
 ) -> List[str]:
     from openff.toolkit.topology import Molecule
 
-    from openff.bespokefit.executor import BespokeExecutor
+    from openff.bespokefit.executor import BespokeFitClient
+    from openff.bespokefit.executor.services import current_settings
+
+    settings = current_settings()
+    client = BespokeFitClient(settings=settings)
 
     console.print(Padding("1. preparing the bespoke workflow", (0, 0, 1, 0)))
 
@@ -273,7 +277,7 @@ def _submit(
         transient=True,
         console=console,
     ):
-        response_ids.append(BespokeExecutor.submit(input_schema))
+        response_ids.append(client.submit_optimization(input_schema=input_schema))
 
     console.print("[[green]✓[/green]] the following workflows were submitted")
     table = Table()

--- a/openff/bespokefit/cli/executor/watch.py
+++ b/openff/bespokefit/cli/executor/watch.py
@@ -23,9 +23,13 @@ def watch_cli(optimization_id):
     console = rich.get_console()
     print_header(console)
 
-    from openff.bespokefit.executor import wait_until_complete
+    from openff.bespokefit.executor import BespokeFitClient
+    from openff.bespokefit.executor.services import current_settings
+
+    settings = current_settings()
+    client = BespokeFitClient(settings=settings)
 
     with handle_common_errors(console) as error_state:
-        wait_until_complete(optimization_id)
+        client.wait_until_complete(optimization_id=optimization_id, console=console)
     if error_state["has_errored"]:
         raise click.exceptions.Exit(code=2)

--- a/openff/bespokefit/cli/worker.py
+++ b/openff/bespokefit/cli/worker.py
@@ -1,12 +1,4 @@
-import importlib
-
 import click
-import rich
-from rich import pretty
-
-from openff.bespokefit.cli.utilities import print_header
-from openff.bespokefit.executor.services import current_settings
-from openff.bespokefit.executor.utilities.celery import spawn_worker
 
 worker_types = ["fragmenter", "qc-compute", "optimizer"]
 
@@ -34,6 +26,14 @@ def worker_cli(worker_type: str):
 
         worker_type: The alias name of the worker type which should be started.
     """
+    import importlib
+
+    import rich
+    from rich import pretty
+
+    from openff.bespokefit.cli.utilities import print_header
+    from openff.bespokefit.executor.services import current_settings
+    from openff.bespokefit.executor.utilities.celery import spawn_worker
 
     pretty.install()
 

--- a/openff/bespokefit/executor/__init__.py
+++ b/openff/bespokefit/executor/__init__.py
@@ -5,7 +5,11 @@ from openff.bespokefit.executor.client import (
     BespokeExecutorStageOutput,
     BespokeFitClient,
 )
-from openff.bespokefit.executor.executor import BespokeExecutor, BespokeWorkerConfig
+from openff.bespokefit.executor.executor import (
+    BespokeExecutor,
+    BespokeWorkerConfig,
+    wait_until_complete,
+)
 
 __all__ = [
     "BespokeExecutor",
@@ -13,4 +17,5 @@ __all__ = [
     "BespokeExecutorStageOutput",
     "BespokeWorkerConfig",
     "BespokeFitClient",
+    "wait_until_complete",
 ]

--- a/openff/bespokefit/executor/__init__.py
+++ b/openff/bespokefit/executor/__init__.py
@@ -1,17 +1,16 @@
 """Tools for executing workflows"""
 
-from openff.bespokefit.executor.executor import (
-    BespokeExecutor,
+from openff.bespokefit.executor.client import (
     BespokeExecutorOutput,
     BespokeExecutorStageOutput,
-    BespokeWorkerConfig,
-    wait_until_complete,
+    BespokeFitClient,
 )
+from openff.bespokefit.executor.executor import BespokeExecutor, BespokeWorkerConfig
 
 __all__ = [
     "BespokeExecutor",
     "BespokeExecutorOutput",
     "BespokeExecutorStageOutput",
     "BespokeWorkerConfig",
-    "wait_until_complete",
+    "BespokeFitClient",
 ]

--- a/openff/bespokefit/executor/client.py
+++ b/openff/bespokefit/executor/client.py
@@ -143,9 +143,9 @@ class BespokeFitClient:
         self._session.headers.update({"bespokefit-token": settings.BEFLOW_API_TOKEN})
         retry = Retry(connect=retries, backoff_factor=backoff_factor)
         adapter = HTTPAdapter(max_retries=retry)
-        self._session.mount("http://", adapter)
+        self._session.mount("http", adapter)
         self.address = (
-            f"http://{settings.BEFLOW_GATEWAY_ADDRESS}:{settings.BEFLOW_GATEWAY_PORT}"
+            f"{settings.BEFLOW_GATEWAY_ADDRESS}:{settings.BEFLOW_GATEWAY_PORT}"
         )
         self.executor_url = f"{self.address}{settings.BEFLOW_API_V1_STR}/"
         self.coordinator_url = (

--- a/openff/bespokefit/executor/client.py
+++ b/openff/bespokefit/executor/client.py
@@ -176,8 +176,7 @@ class BespokeFitClient:
         coordinator_request = self._session.get(optimization_href)
         coordinator_request.raise_for_status()
 
-        response = CoordinatorGETResponse.parse_raw(coordinator_request.text)
-        return response
+        return CoordinatorGETResponse.parse_raw(coordinator_request.text)
 
     def get_optimization(self, optimization_id: str) -> BespokeExecutorOutput:
         """Retrieve the current state of a running bespoke fitting workflow.
@@ -280,7 +279,8 @@ class BespokeFitClient:
         import time
 
         while True:
-            response = self.get_optimization(optimization_id=optimization_id)
+            query = f"{self.coordinator_url}/{optimization_id}"
+            response = self._query_coordinator(optimization_href=query)
 
             stage = {stage.type: stage for stage in response.stages}[stage_type]
 

--- a/openff/bespokefit/executor/client.py
+++ b/openff/bespokefit/executor/client.py
@@ -140,7 +140,7 @@ class BespokeFitClient:
         backoff_factor: float = 0.5,
     ):
         self._session = requests.Session()
-        self._session.headers.update({"BespokeFit-token": settings.BEFLOW_API_TOKEN})
+        self._session.headers.update({"bespokefit-token": settings.BEFLOW_API_TOKEN})
         retry = Retry(connect=retries, backoff_factor=backoff_factor)
         adapter = HTTPAdapter(max_retries=retry)
         self._session.mount("http://", adapter)

--- a/openff/bespokefit/executor/client.py
+++ b/openff/bespokefit/executor/client.py
@@ -135,7 +135,6 @@ class BespokeFitClient:
 
     def __init__(
         self,
-        api_address: str,
         settings: Settings,
         retries: int = 3,
         backoff_factor: float = 0.5,
@@ -145,7 +144,10 @@ class BespokeFitClient:
         retry = Retry(connect=retries, backoff_factor=backoff_factor)
         adapter = HTTPAdapter(max_retries=retry)
         self._session.mount("http://", adapter)
-        self.executor_url = f"http://{api_address}:{settings.BEFLOW_GATEWAY_PORT}{settings.BEFLOW_API_V1_STR}/"
+        self.address = (
+            f"http://{settings.BEFLOW_GATEWAY_ADDRESS}:{settings.BEFLOW_GATEWAY_PORT}"
+        )
+        self.executor_url = f"{self.address}{settings.BEFLOW_API_V1_STR}/"
         self.coordinator_url = (
             f"{self.executor_url}{settings.BEFLOW_COORDINATOR_PREFIX}"
         )

--- a/openff/bespokefit/executor/client.py
+++ b/openff/bespokefit/executor/client.py
@@ -143,7 +143,9 @@ class BespokeFitClient:
         self._session.headers.update({"bespokefit-token": settings.BEFLOW_API_TOKEN})
         retry = Retry(connect=retries, backoff_factor=backoff_factor)
         adapter = HTTPAdapter(max_retries=retry)
-        self._session.mount("http", adapter)
+        # replace the defaults with a retry version
+        self._session.mount("http://", adapter)
+        self._session.mount("https://", adapter)
         self.address = (
             f"{settings.BEFLOW_GATEWAY_ADDRESS}:{settings.BEFLOW_GATEWAY_PORT}"
         )

--- a/openff/bespokefit/executor/client.py
+++ b/openff/bespokefit/executor/client.py
@@ -1,0 +1,290 @@
+from typing import TYPE_CHECKING, List, Optional, Type, TypeVar, Union
+
+import requests
+from openff.toolkit.typing.engines.smirnoff import ForceField
+from requests.adapters import HTTPAdapter, Retry
+
+from openff.bespokefit._pydantic import BaseModel, Field
+from openff.bespokefit.executor.services import Settings
+from openff.bespokefit.executor.services.coordinator.models import (
+    CoordinatorGETPageResponse,
+    CoordinatorGETResponse,
+    CoordinatorGETStageStatus,
+    CoordinatorPOSTBody,
+    CoordinatorPOSTResponse,
+)
+from openff.bespokefit.executor.utilities.typing import Status
+from openff.bespokefit.schema.fitting import BespokeOptimizationSchema
+from openff.bespokefit.schema.results import BespokeOptimizationResults
+
+if TYPE_CHECKING:
+    import rich
+
+_T = TypeVar("_T")
+
+
+class BespokeExecutorStageOutput(BaseModel):
+    """A model that stores the output of a particular stage in the bespoke fitting
+    workflow e.g. QC data generation."""
+
+    type: str = Field(..., description="The type of stage.")
+
+    status: Status = Field(..., description="The status of the stage.")
+
+    error: Optional[str] = Field(
+        ..., description="The error, if any, raised by the stage."
+    )
+
+
+class BespokeExecutorOutput(BaseModel):
+    """A model that stores the current output of running bespoke fitting workflow
+    including any partial or final results."""
+
+    smiles: str = Field(
+        ...,
+        description="The SMILES representation of the molecule that the bespoke "
+        "parameters are being generated for.",
+    )
+
+    stages: List[BespokeExecutorStageOutput] = Field(
+        ..., description="The outputs from each stage in the bespoke fitting process."
+    )
+    results: Optional[BespokeOptimizationResults] = Field(
+        None,
+        description="The final result of the bespoke optimization if the full workflow "
+        "is finished, or ``None`` otherwise.",
+    )
+
+    @property
+    def bespoke_force_field(self) -> Optional[ForceField]:
+        """The final bespoke force field if the bespoke fitting workflow is complete."""
+
+        if self.results is None or self.results.refit_force_field is None:
+            return None
+
+        return ForceField(
+            self.results.refit_force_field, allow_cosmetic_attributes=True
+        )
+
+    @property
+    def status(self) -> Status:
+        pending_stages = [stage for stage in self.stages if stage.status == "waiting"]
+
+        running_stages = [stage for stage in self.stages if stage.status == "running"]
+        assert len(running_stages) < 2
+
+        running_stage = None if len(running_stages) == 0 else running_stages[0]
+
+        complete_stages = [
+            stage
+            for stage in self.stages
+            if stage not in pending_stages and stage not in running_stages
+        ]
+
+        if (
+            running_stage is None
+            and len(complete_stages) == 0
+            and len(pending_stages) > 0
+        ):
+            return "waiting"
+
+        if any(stage.status == "errored" for stage in complete_stages):
+            return "errored"
+
+        if running_stage is not None or len(pending_stages) > 0:
+            return "running"
+
+        if all(stage.status == "success" for stage in complete_stages):
+            return "success"
+
+        raise NotImplementedError()
+
+    @property
+    def error(self) -> Optional[str]:
+        """The error that caused the fitting to fail if any"""
+
+        if self.status != "errored":
+            return None
+
+        message = next(
+            iter(stage.error for stage in self.stages if stage.status == "errored")
+        )
+        return "unknown error" if message is None else message
+
+    @classmethod
+    def from_response(cls: Type[_T], response: CoordinatorGETResponse) -> _T:
+        """Creates an instance of this object from the response from a bespoke
+        coordinator service."""
+
+        return cls(
+            smiles=response.smiles,
+            stages=[
+                BespokeExecutorStageOutput(
+                    type=stage.type, status=stage.status, error=stage.error
+                )
+                for stage in response.stages
+            ],
+            results=response.results,
+        )
+
+
+class BespokeFitClient:
+    """
+    A client interface which can be used to connect to a BespokeFit executor instance to submit and retrieve results.
+    """
+
+    def __init__(
+        self,
+        api_address: str,
+        settings: Settings,
+        retries: int = 3,
+        backoff_factor: float = 0.5,
+    ):
+        self._session = requests.Session()
+        self._session.headers.update({"BespokeFit-token": settings.BEFLOW_API_TOKEN})
+        retry = Retry(connect=retries, backoff_factor=backoff_factor)
+        adapter = HTTPAdapter(max_retries=retry)
+        self._session.mount("http://", adapter)
+        self.executor_url = f"http://{api_address}:{settings.BEFLOW_GATEWAY_PORT}{settings.BEFLOW_API_V1_STR}/"
+        self.coordinator_url = (
+            f"{self.executor_url}{settings.BEFLOW_COORDINATOR_PREFIX}"
+        )
+        self.fragmenter_url = f"{self.executor_url}{settings.BEFLOW_FRAGMENTER_PREFIX}"
+        self.qc_compute_url = f"{self.executor_url}{settings.BEFLOW_QC_COMPUTE_PREFIX}"
+        self.optimizer_url = f"{self.executor_url}{settings.BEFLOW_OPTIMIZER_PREFIX}"
+
+    def submit_optimization(self, input_schema: BespokeOptimizationSchema) -> str:
+        """Submits a new bespoke fitting workflow to the executor.
+
+        Args:
+            input_schema: The schema defining the optimization to perform.
+
+        Returns:
+            The unique ID assigned to the optimization to perform.
+        """
+        request = self._session.post(
+            self.coordinator_url,
+            data=CoordinatorPOSTBody(input_schema=input_schema).json(),
+        )
+        request.raise_for_status()
+
+        return CoordinatorPOSTResponse.parse_raw(request.text).id
+
+    def _query_coordinator(self, optimization_href: str) -> CoordinatorGETResponse:
+        coordinator_request = self._session.get(optimization_href)
+        coordinator_request.raise_for_status()
+
+        response = CoordinatorGETResponse.parse_raw(coordinator_request.text)
+        return response
+
+    def get_optimization(self, optimization_id: str) -> BespokeExecutorOutput:
+        """Retrieve the current state of a running bespoke fitting workflow.
+
+        Args:
+            optimization_id: The unique ID associated with the running optimization.
+
+        Returns:
+            The BespokeExecutorOutput which contains information about the optimization and links the relevant
+            stages as well as the final parameters if the optimization if finished.
+        """
+
+        optimization_href = f"{self.coordinator_url}/{optimization_id}"
+        return BespokeExecutorOutput.from_response(
+            self._query_coordinator(optimization_href=optimization_href)
+        )
+
+    def list_optimizations(
+        self, status: Optional[Status] = None
+    ) -> CoordinatorGETPageResponse:
+        """
+        Get a list the first 1000 running calculations with the requested status.
+
+        Args:
+            status: The status we want to check.
+
+        Returns:
+            A CoordinatorGETPageResponse linking to the relevant optimization ids which can then be sorted.
+        """
+        # In the coordinator we keep both successful and errored tasks in the same 'complete'
+        # queue to avoid having to maintain and query to separate lists in redis, so here we
+        # need to condense these two states into one and then apply a second filter when
+        # iterating over the returned ids.
+        status_url = (
+            None
+            if status is None
+            else status.replace("success", "complete").replace("errored", "complete")
+        )
+        status_url = "" if status_url is None else f"?status={status_url}"
+        request = self._session.get(f"{self.coordinator_url}{status_url}")
+        request.raise_for_status()
+
+        return CoordinatorGETPageResponse.parse_raw(request.content)
+
+    def wait_until_complete(
+        self,
+        optimization_id: str,
+        console: Optional["rich.Console"] = None,
+        frequency: Union[int, float] = 5,
+    ) -> BespokeExecutorOutput:
+        """Wait for a specified optimization to complete and return the results.
+
+        Args:
+            optimization_id: The unique id of the optimization to wait for.
+            console: The console to print to.
+            frequency: The frequency (seconds) with which to poll the status of the
+                optimization.
+
+        Returns:
+            The output of running the optimization.
+        """
+        import rich
+        from rich.padding import Padding
+
+        console = console if console is not None else rich.get_console()
+
+        optimization_response = self.get_optimization(optimization_id=optimization_id)
+        stage_types = [stage.type for stage in optimization_response.stages]
+
+        stage_messages = {
+            "fragmentation": "fragmenting the molecule",
+            "qc-generation": "generating bespoke QC data",
+            "optimization": "optimizing the parameters",
+        }
+
+        for stage_type in stage_messages:
+            if stage_type not in stage_types:
+                continue
+
+            with console.status(stage_messages[stage_type]):
+                stage = self._wait_for_stage(
+                    optimization_id=optimization_id,
+                    stage_type=stage_type,
+                    frequency=frequency,
+                )
+
+            if stage.status == "errored":
+                console.print(f"[[red]x[/red]] {stage_type} failed")
+                console.print(Padding(stage.error, (1, 0, 0, 1)))
+
+                break
+
+            console.print(f"[[green]✓[/green]] {stage_type} successful")
+
+        return self.get_optimization(optimization_id=optimization_id)
+
+    def _wait_for_stage(
+        self, optimization_id: str, stage_type: str, frequency: Union[int, float] = 5
+    ) -> CoordinatorGETStageStatus:
+        import time
+
+        while True:
+            response = self.get_optimization(optimization_id=optimization_id)
+
+            stage = {stage.type: stage for stage in response.stages}[stage_type]
+
+            if stage.status in ["errored", "success"]:
+                break
+
+            time.sleep(frequency)
+
+        return stage

--- a/openff/bespokefit/executor/client.py
+++ b/openff/bespokefit/executor/client.py
@@ -139,6 +139,13 @@ class BespokeFitClient:
         retries: int = 3,
         backoff_factor: float = 0.5,
     ):
+        # If we are using a token with https warn the user
+        if settings.BEFLOW_API_TOKEN and "https" not in settings.BEFLOW_GATEWAY_ADDRESS:
+            import warnings
+
+            warnings.warn(
+                "Using an API token without an https connection is insecure, consider using https for encrypted comunication."
+            )
         self._session = requests.Session()
         self._session.headers.update({"bespokefit-token": settings.BEFLOW_API_TOKEN})
         retry = Retry(connect=retries, backoff_factor=backoff_factor)

--- a/openff/bespokefit/executor/executor.py
+++ b/openff/bespokefit/executor/executor.py
@@ -6,49 +6,21 @@ import multiprocessing
 import os
 import shutil
 import subprocess
-import time
 from tempfile import mkdtemp
-from typing import List, Optional, Type, TypeVar, Union
+from typing import List, Optional, Union
 
 import celery
-import requests
-import rich
-from openff.toolkit.typing.engines.smirnoff import ForceField
-from rich.padding import Padding
 from typing_extensions import Literal
 
 from openff.bespokefit._pydantic import BaseModel, Field
 from openff.bespokefit.executor.services import Settings, current_settings
-from openff.bespokefit.executor.services.coordinator.models import (
-    CoordinatorGETResponse,
-    CoordinatorGETStageStatus,
-    CoordinatorPOSTBody,
-    CoordinatorPOSTResponse,
-)
 from openff.bespokefit.executor.services.gateway import launch as launch_gateway
 from openff.bespokefit.executor.services.gateway import wait_for_gateway
 from openff.bespokefit.executor.utilities.celery import spawn_worker
 from openff.bespokefit.executor.utilities.redis import is_redis_available, launch_redis
-from openff.bespokefit.executor.utilities.typing import Status
-from openff.bespokefit.schema.fitting import BespokeOptimizationSchema
-from openff.bespokefit.schema.results import BespokeOptimizationResults
 from openff.bespokefit.utilities.tempcd import temporary_cd
 
-_T = TypeVar("_T")
-
 _logger = logging.getLogger(__name__)
-
-
-def _base_endpoint():
-    settings = current_settings()
-    return (
-        f"http://127.0.0.1:{settings.BEFLOW_GATEWAY_PORT}{settings.BEFLOW_API_V1_STR}/"
-    )
-
-
-def _coordinator_endpoint():
-    settings = current_settings()
-    return f"{_base_endpoint()}{settings.BEFLOW_COORDINATOR_PREFIX}"
 
 
 class BespokeWorkerConfig(BaseModel):
@@ -65,111 +37,6 @@ class BespokeWorkerConfig(BaseModel):
         "is available for this worker. This number may be ignored depending on the "
         "task type.",
     )
-
-
-class BespokeExecutorStageOutput(BaseModel):
-    """A model that stores the output of a particular stage in the bespoke fitting
-    workflow e.g. QC data generation."""
-
-    type: str = Field(..., description="The type of stage.")
-
-    status: Status = Field(..., description="The status of the stage.")
-
-    error: Optional[str] = Field(
-        ..., description="The error, if any, raised by the stage."
-    )
-
-
-class BespokeExecutorOutput(BaseModel):
-    """A model that stores the current output of running bespoke fitting workflow
-    including any partial or final results."""
-
-    smiles: str = Field(
-        ...,
-        description="The SMILES representation of the molecule that the bespoke "
-        "parameters are being generated for.",
-    )
-
-    stages: List[BespokeExecutorStageOutput] = Field(
-        ..., description="The outputs from each stage in the bespoke fitting process."
-    )
-    results: Optional[BespokeOptimizationResults] = Field(
-        None,
-        description="The final result of the bespoke optimization if the full workflow "
-        "is finished, or ``None`` otherwise.",
-    )
-
-    @property
-    def bespoke_force_field(self) -> Optional[ForceField]:
-        """The final bespoke force field if the bespoke fitting workflow is complete."""
-
-        if self.results is None or self.results.refit_force_field is None:
-            return None
-
-        return ForceField(
-            self.results.refit_force_field, allow_cosmetic_attributes=True
-        )
-
-    @property
-    def status(self) -> Status:
-        pending_stages = [stage for stage in self.stages if stage.status == "waiting"]
-
-        running_stages = [stage for stage in self.stages if stage.status == "running"]
-        assert len(running_stages) < 2
-
-        running_stage = None if len(running_stages) == 0 else running_stages[0]
-
-        complete_stages = [
-            stage
-            for stage in self.stages
-            if stage not in pending_stages and stage not in running_stages
-        ]
-
-        if (
-            running_stage is None
-            and len(complete_stages) == 0
-            and len(pending_stages) > 0
-        ):
-            return "waiting"
-
-        if any(stage.status == "errored" for stage in complete_stages):
-            return "errored"
-
-        if running_stage is not None or len(pending_stages) > 0:
-            return "running"
-
-        if all(stage.status == "success" for stage in complete_stages):
-            return "success"
-
-        raise NotImplementedError()
-
-    @property
-    def error(self) -> Optional[str]:
-        """The error that caused the fitting to fail if any"""
-
-        if self.status != "errored":
-            return None
-
-        message = next(
-            iter(stage.error for stage in self.stages if stage.status == "errored")
-        )
-        return "unknown error" if message is None else message
-
-    @classmethod
-    def from_response(cls: Type[_T], response: CoordinatorGETResponse) -> _T:
-        """Creates an instance of this object from the response from a bespoke
-        coordinator service."""
-
-        return cls(
-            smiles=response.smiles,
-            stages=[
-                BespokeExecutorStageOutput(
-                    type=stage.type, status=stage.status, error=stage.error
-                )
-                for stage in response.stages
-            ],
-            results=response.results,
-        )
 
 
 class BespokeExecutor:
@@ -349,114 +216,9 @@ class BespokeExecutor:
         if self._remove_directory:
             shutil.rmtree(self._directory, ignore_errors=True)
 
-    @staticmethod
-    def submit(input_schema: BespokeOptimizationSchema) -> str:
-        """Submits a new bespoke fitting workflow to the executor.
-
-        Args:
-            input_schema: The schema defining the optimization to perform.
-
-        Returns:
-            The unique ID assigned to the optimization to perform.
-        """
-        request = requests.post(
-            _coordinator_endpoint(),
-            data=CoordinatorPOSTBody(input_schema=input_schema).json(),
-        )
-        request.raise_for_status()
-
-        return CoordinatorPOSTResponse.parse_raw(request.text).id
-
-    @staticmethod
-    def retrieve(optimization_id: str) -> BespokeExecutorOutput:
-        """Retrieve the current state of a running bespoke fitting workflow.
-
-        Args:
-            optimization_id: The unique ID associated with the running optimization.
-        """
-
-        optimization_href = f"{_coordinator_endpoint()}/{optimization_id}"
-
-        return BespokeExecutorOutput.from_response(
-            _query_coordinator(optimization_href)
-        )
-
     def __enter__(self):
         self._start(asynchronous=True)
         return self
 
     def __exit__(self, *args):
         self._stop()
-
-
-def _query_coordinator(optimization_href: str) -> CoordinatorGETResponse:
-    coordinator_request = requests.get(optimization_href)
-    coordinator_request.raise_for_status()
-
-    response = CoordinatorGETResponse.parse_raw(coordinator_request.text)
-    return response
-
-
-def _wait_for_stage(
-    optimization_href: str, stage_type: str, frequency: Union[int, float] = 5
-) -> CoordinatorGETStageStatus:
-    while True:
-        response = _query_coordinator(optimization_href)
-
-        stage = {stage.type: stage for stage in response.stages}[stage_type]
-
-        if stage.status in ["errored", "success"]:
-            break
-
-        time.sleep(frequency)
-
-    return stage
-
-
-def wait_until_complete(
-    optimization_id: str,
-    console: Optional["rich.Console"] = None,
-    frequency: Union[int, float] = 5,
-) -> BespokeExecutorOutput:
-    """Wait for a specified optimization to complete and return the results.
-
-    Args:
-        optimization_id: The unique id of the optimization to wait for.
-        console: The console to print to.
-        frequency: The frequency (seconds) with which to poll the status of the
-            optimization.
-
-    Returns:
-        The output of running the optimization.
-    """
-
-    console = console if console is not None else rich.get_console()
-
-    optimization_href = f"{_coordinator_endpoint()}/{optimization_id}"
-
-    initial_response = _query_coordinator(optimization_href)
-    stage_types = [stage.type for stage in initial_response.stages]
-
-    stage_messages = {
-        "fragmentation": "fragmenting the molecule",
-        "qc-generation": "generating bespoke QC data",
-        "optimization": "optimizing the parameters",
-    }
-
-    for stage_type in stage_messages:
-        if stage_type not in stage_types:
-            continue
-
-        with console.status(stage_messages[stage_type]):
-            stage = _wait_for_stage(optimization_href, stage_type, frequency)
-
-        if stage.status == "errored":
-            console.print(f"[[red]x[/red]] {stage_type} failed")
-            console.print(Padding(stage.error, (1, 0, 0, 1)))
-
-            break
-
-        console.print(f"[[green]✓[/green]] {stage_type} successful")
-
-    final_response = _query_coordinator(optimization_href)
-    return BespokeExecutorOutput.from_response(final_response)

--- a/openff/bespokefit/executor/services/coordinator/stages.py
+++ b/openff/bespokefit/executor/services/coordinator/stages.py
@@ -119,6 +119,7 @@ class FragmentationStage(_Stage):
                     fragmenter=task.input_schema.fragmentation_engine,
                     target_bond_smarts=task.input_schema.target_torsion_smirks,
                 ).json(),
+                headers={"bespokefit-token": settings.BEFLOW_API_TOKEN},
             )
 
             if raw_response.status_code != 200:
@@ -144,7 +145,8 @@ class FragmentationStage(_Stage):
                 f"http://127.0.0.1:"
                 f"{settings.BEFLOW_GATEWAY_PORT}"
                 f"{settings.BEFLOW_API_V1_STR}/"
-                f"{settings.BEFLOW_FRAGMENTER_PREFIX}/{self.id}"
+                f"{settings.BEFLOW_FRAGMENTER_PREFIX}/{self.id}",
+                headers={"bespokefit-token": settings.BEFLOW_API_TOKEN},
             )
 
             if raw_response.status_code != 200:
@@ -393,6 +395,7 @@ class QCGenerationStage(_Stage):
                         f"{settings.BEFLOW_API_V1_STR}/"
                         f"{settings.BEFLOW_QC_COMPUTE_PREFIX}",
                         data=QCGeneratorPOSTBody(input_schema=qc_task).json(),
+                        headers={"bespokefit-token": settings.BEFLOW_API_TOKEN},
                     )
 
                     if raw_response.status_code != 200:
@@ -429,7 +432,8 @@ class QCGenerationStage(_Stage):
                 f"http://127.0.0.1:"
                 f"{settings.BEFLOW_GATEWAY_PORT}"
                 f"{settings.BEFLOW_API_V1_STR}/"
-                f"{settings.BEFLOW_QC_COMPUTE_PREFIX}?ids={id_query}"
+                f"{settings.BEFLOW_QC_COMPUTE_PREFIX}?ids={id_query}",
+                headers={"bespokefit-token": settings.BEFLOW_API_TOKEN},
             )
             contents = raw_response.text
 
@@ -546,6 +550,7 @@ class OptimizationStage(_Stage):
                 data=serialize(
                     OptimizerPOSTBody(input_schema=input_schema), encoding="json"
                 ),
+                headers={"bespokefit-token": settings.BEFLOW_API_TOKEN},
             )
 
             if raw_response.status_code != 200:
@@ -568,7 +573,8 @@ class OptimizationStage(_Stage):
                 f"http://127.0.0.1:"
                 f"{settings.BEFLOW_GATEWAY_PORT}"
                 f"{settings.BEFLOW_API_V1_STR}/"
-                f"{settings.BEFLOW_OPTIMIZER_PREFIX}/{self.id}"
+                f"{settings.BEFLOW_OPTIMIZER_PREFIX}/{self.id}",
+                headers={"bespokefit-token": settings.BEFLOW_API_TOKEN},
             )
             contents = raw_response.text
 

--- a/openff/bespokefit/executor/services/gateway.py
+++ b/openff/bespokefit/executor/services/gateway.py
@@ -33,7 +33,8 @@ __settings = current_settings()
 def check_token(request: Request) -> bool:
     """A simple authentication check."""
     token = request.headers["BespokeFit-token"]
-    if token != __settings.BEFLOW_API_TOKEN:
+    # load the current key from the env and check
+    if token != current_settings().BEFLOW_API_TOKEN:
         raise HTTPException(status_code=401, detail="Unauthorized")
     return True
 
@@ -98,12 +99,13 @@ def launch(directory: Optional[str] = None, log_file: Optional[str] = None):
 
 def wait_for_gateway(n_retries: int = 40):
     timeout = True
-
+    # load the settings again to check the API token
+    settings = current_settings()
     for _ in range(n_retries):
         try:
             ping = requests.get(
-                f"http://127.0.0.1:{__settings.BEFLOW_GATEWAY_PORT}{__settings.BEFLOW_API_V1_STR}",
-                headers={"BespokeFit-token": __settings.BEFLOW_API_TOKEN},
+                f"http://127.0.0.1:{settings.BEFLOW_GATEWAY_PORT}{settings.BEFLOW_API_V1_STR}",
+                headers={"BespokeFit-token": settings.BEFLOW_API_TOKEN},
             )
             ping.raise_for_status()
 

--- a/openff/bespokefit/executor/services/gateway.py
+++ b/openff/bespokefit/executor/services/gateway.py
@@ -103,7 +103,7 @@ def wait_for_gateway(n_retries: int = 40):
         try:
             ping = requests.get(
                 f"http://127.0.0.1:{__settings.BEFLOW_GATEWAY_PORT}{__settings.BEFLOW_API_V1_STR}",
-                headers={"BespokeFit": __settings.BEFLOW_API_TOKEN},
+                headers={"BespokeFit-token": __settings.BEFLOW_API_TOKEN},
             )
             ping.raise_for_status()
 

--- a/openff/bespokefit/executor/services/gateway.py
+++ b/openff/bespokefit/executor/services/gateway.py
@@ -32,7 +32,7 @@ __settings = current_settings()
 
 def check_token(request: Request) -> bool:
     """A simple authentication check."""
-    token = request.headers["BespokeFit-token"]
+    token = request.headers["bespokefit-token"]
     # load the current key from the env and check
     if token != current_settings().BEFLOW_API_TOKEN:
         raise HTTPException(status_code=401, detail="Unauthorized")
@@ -99,13 +99,13 @@ def launch(directory: Optional[str] = None, log_file: Optional[str] = None):
 
 def wait_for_gateway(n_retries: int = 40):
     timeout = True
-    # load the settings again to check the API token
+    # load the settings again to get the most recent token
     settings = current_settings()
     for _ in range(n_retries):
         try:
             ping = requests.get(
                 f"http://127.0.0.1:{settings.BEFLOW_GATEWAY_PORT}{settings.BEFLOW_API_V1_STR}",
-                headers={"BespokeFit-token": settings.BEFLOW_API_TOKEN},
+                headers={"bespokefit-token": settings.BEFLOW_API_TOKEN},
             )
             ping.raise_for_status()
 

--- a/openff/bespokefit/executor/utilities/celery.py
+++ b/openff/bespokefit/executor/utilities/celery.py
@@ -51,6 +51,7 @@ def configure_celery_app(
     celery_app.conf.task_default_queue = app_name
     celery_app.conf.broker_transport_options = {"visibility_timeout": 1000000}
     celery_app.conf.result_expires = None
+    celery_app.conf.task_reject_on_worker_lost = True
 
     return celery_app
 

--- a/openff/bespokefit/utilities/_settings.py
+++ b/openff/bespokefit/utilities/_settings.py
@@ -20,6 +20,7 @@ class WorkerSettings(BaseModel):
 
 class Settings(BaseSettings):
     BEFLOW_API_V1_STR: str = "/api/v1"
+    BEFLOW_API_TOKEN: str = ""
 
     BEFLOW_GATEWAY_PORT: int = 8000
     BEFLOW_GATEWAY_LOG_LEVEL: str = "error"

--- a/openff/bespokefit/utilities/_settings.py
+++ b/openff/bespokefit/utilities/_settings.py
@@ -23,6 +23,7 @@ class Settings(BaseSettings):
     BEFLOW_API_TOKEN: str = ""
 
     BEFLOW_GATEWAY_PORT: int = 8000
+    BEFLOW_GATEWAY_ADDRESS: str = "127.0.0.1"
     BEFLOW_GATEWAY_LOG_LEVEL: str = "error"
 
     BEFLOW_REDIS_ADDRESS: str = "localhost"

--- a/openff/bespokefit/utilities/_settings.py
+++ b/openff/bespokefit/utilities/_settings.py
@@ -23,7 +23,7 @@ class Settings(BaseSettings):
     BEFLOW_API_TOKEN: str = ""
 
     BEFLOW_GATEWAY_PORT: int = 8000
-    BEFLOW_GATEWAY_ADDRESS: str = "127.0.0.1"
+    BEFLOW_GATEWAY_ADDRESS: str = "http://127.0.0.1"
     BEFLOW_GATEWAY_LOG_LEVEL: str = "error"
 
     BEFLOW_REDIS_ADDRESS: str = "localhost"


### PR DESCRIPTION
## Description
This PR introduces a simple bespokefit client which splits out the logic of communicating with the executor. This should make it easier to submit and retrieve calculations from an executor on another machine using the python API similarly to Alchemiscale or QCArchive. To enable this we also expose the `BEFLOW_GATEWAY_ADDRESS` which can be used to provide the location of an executor on another machine which is currently not possible. 

We also introduce some basic authentication which checks that the value of the new setting `BEFLOW_API_TOKEN` matches between the server and the client value before responding to requests. 

These features should make it easier to provide a light weight bespokefit-client package in future for applications which only need to interface with a bespokefit executor. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] add authentication and testing
  - [x] add bespokefit client and testing
  - [x] update all CLI commands
  - [x] update docs using the old interface

## Questions
- [ ] ~~should we keep the old API points and raise a deprecation warning if they are used?~~ 
- [x] Patch the methods on the executor to go via the client

## Status
- [x] Ready to go