### PR TITLE
Revert "Avoid RDKit 2024.03.4"

### DIFF
--- a/devtools/conda-envs/no_openeye.yaml
+++ b/devtools/conda-envs/no_openeye.yaml
@@ -18,7 +18,7 @@ dependencies:
   - rich
   - click
   - click-option-group
-  - rdkit !=2024.03.4
+  - rdkit >=22
   - ambertools >=22
   - openff-utilities
   - openff-toolkit-base =0.15

--- a/devtools/conda-envs/no_openeye.yaml
+++ b/devtools/conda-envs/no_openeye.yaml
@@ -18,7 +18,7 @@ dependencies:
   - rich
   - click
   - click-option-group
-  - rdkit >=22
+  - rdkit
   - ambertools >=22
   - openff-utilities
   - openff-toolkit-base =0.15

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -19,7 +19,7 @@ dependencies:
   - rich
   - click
   - click-option-group
-  - rdkit !=2024.03.4
+  - rdkit
   - openff-utilities
   - openff-toolkit-base =0.15
   - openff-interchange  # only needed because openff-toolkit-base


### PR DESCRIPTION
Reverts openforcefield/openff-bespokefit#353

This was a problem with the builds, not RDKit itself. Greg and others identified it and pulled it offline:


https://github.com/conda-forge/rdkit-feedstock/issues/162

https://github.com/conda-forge/admin-requests/pull/1034