### PR TITLE
Update install steps 

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -11,7 +11,7 @@ the two sections below ("Fragmentation Backends" and "Reference Data
 Generators")
 
 ```shell
-mamba install -c conda-forge openff-bespokefit "qcportal <0.50"
+mamba install -c conda-forge openff-bespokefit
 ```
 
 If you do not have Mamba installed, see the [OpenFF installation documentation](openff.docs:install).


### PR DESCRIPTION
Doing `"qcportal <0.50"` will pull down version `0.2.3` of bespokefit