### PR TITLE
Relax Toolkit version in CI

### DIFF
--- a/devtools/conda-envs/no_openeye.yaml
+++ b/devtools/conda-envs/no_openeye.yaml
@@ -21,7 +21,7 @@ dependencies:
   - rdkit =2024.03.5
   - ambertools >=22
   - openff-utilities
-  - openff-toolkit-base =0.15
+  - openff-toolkit-base >=0.15
   - openff-interchange  # only needed because openff-toolkit-base
   - openff-forcefields >=2024.04.0
   - openff-qcsubmit >=0.50

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -19,9 +19,9 @@ dependencies:
   - rich
   - click
   - click-option-group
-  - rdkit =2024.03.5
+  - rdkit >=2024.03.5
   - openff-utilities
-  - openff-toolkit-base =0.15
+  - openff-toolkit-base >=0.15
   - openff-interchange  # only needed because openff-toolkit-base
   - openff-forcefields >=2024.04.0
   - openff-units

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -19,7 +19,7 @@ dependencies:
   - rich
   - click
   - click-option-group
-  - rdkit >=2024.03.5
+  - rdkit =2024.03.5
   - openff-utilities
   - openff-toolkit-base >=0.15
   - openff-interchange  # only needed because openff-toolkit-base


### PR DESCRIPTION
This brings the OFFTK version pin in this CI back in line with the [conda feedstock version pin](https://github.com/conda-forge/openff-bespokefit-feedstock/blob/main/recipe/meta.yaml#L33)